### PR TITLE
Allow log extension for xyz files

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,3 +1,3 @@
 name = "mctc-lib"
-version = "0.1.0"
+version = "0.1.2"
 license = "Apache-2.0"

--- a/man/mctc-convert.1.adoc
+++ b/man/mctc-convert.1.adoc
@@ -1,0 +1,43 @@
+= mctc-convert(1)
+:doctype: manpage
+
+== Name
+mctc-convert - Convert between supported input formats of the tool chain library
+
+
+== Synopsis
+*mctc-convert* [_options_] _input_ _output_
+
+
+== Description
+
+Read structure from input file and writes it to output file.
+The format is determined by the file extension or the format hint.
+
+Supported formats:
+
+- Xmol/xyz files (xyz, log)
+- Turbomole's coord, riper's periodic coord (tmol, coord)
+- DFTB+ genFormat geometry inputs as cluster, supercell or fractional (gen)
+- VASP's POSCAR/CONTCAR input files (vasp, poscar, contcar)
+- Protein Database files, only single files (pdb)
+- Connection table files, molfile (mol) and structure data format (sdf)
+- Gaussian's external program input (ein)
+
+
+== Options
+
+*-i, --input* _format_::
+Hint for the format of the input file
+
+*-o, --output* _format_::
+Hint for the format of the output file
+
+*--normalize*::
+Normalize all element symbols to capitalized format
+
+*--version*::
+Print program version and exit
+
+*--help*::
+Show this help message

--- a/meson.build
+++ b/meson.build
@@ -70,6 +70,17 @@ if install
     mctc_lib,
     description: 'Modular computation tool chain',
   )
+
+  asciidoc = find_program('asciidoctor', required: false)
+  if asciidoc.found()
+    install_man(
+      configure_file(
+        command: [asciidoc, '-b', 'manpage', '@INPUT@', '-o', '@OUTPUT@'],
+        input: files('man/mctc-convert.1.adoc'),
+        output: '@BASENAME@',
+      )
+    )
+  endif
 endif
 
 # add the testsuite

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@
 project(
   'mctc-lib',
   'fortran',
-  version: '0.1.1',
+  version: '0.1.2',
   license: 'Apache-2.0',
   meson_version: '>=0.53',
   default_options: [

--- a/src/mctc/io/filetype.f90
+++ b/src/mctc/io/filetype.f90
@@ -77,7 +77,7 @@ elemental function get_filetype(file) result(ftype)
       select case(to_lower(file(iext+1:)))
       case('coord', 'tmol')
          ftype = filetype%tmol
-      case('xyz')
+      case('xyz', 'log')
          ftype = filetype%xyz
       case('mol')
          ftype = filetype%molfile

--- a/src/mctc/io/write/xyz.f90
+++ b/src/mctc/io/write/xyz.f90
@@ -29,6 +29,7 @@ subroutine write_xyz(mol, unit, comment_line)
    integer, intent(in) :: unit
    character(len=*), intent(in), optional :: comment_line
    integer :: iat
+   logical :: expo
 
    write(unit, '(i0)') mol%nat
    if (present(comment_line)) then
@@ -36,10 +37,18 @@ subroutine write_xyz(mol, unit, comment_line)
    else
       write(unit, '(a)')
    end if
-   do iat = 1, mol%nat
-      write(unit, '(a4, 1x, 3es24.14)') &
-         & mol%sym(mol%id(iat)), mol%xyz(:, iat)*autoaa
-   enddo
+   expo = maxval(mol%xyz) > 1.0e+5 .or. minval(mol%xyz) < -1.0e+5
+   if (expo) then
+      do iat = 1, mol%nat
+         write(unit, '(a4, 1x, 3es24.14)') &
+            & mol%sym(mol%id(iat)), mol%xyz(:, iat)*autoaa
+      enddo
+   else
+      do iat = 1, mol%nat
+         write(unit, '(a4, 1x, 3f24.14)') &
+            & mol%sym(mol%id(iat)), mol%xyz(:, iat)*autoaa
+      enddo
+   end if
 
 end subroutine write_xyz
 

--- a/src/mctc/version.f90
+++ b/src/mctc/version.f90
@@ -21,10 +21,10 @@ module mctc_version
 
 
    !> String representation of the mctc-lib version
-   character(len=*), parameter :: mctc_version_string = "0.1.1"
+   character(len=*), parameter :: mctc_version_string = "0.1.2"
 
    !> Numeric representation of the mctc-lib version
-   integer, parameter :: mctc_version_compact(3) = [0, 1, 1]
+   integer, parameter :: mctc_version_compact(3) = [0, 1, 2]
 
 
 contains


### PR DESCRIPTION
- only write xyz in exponential notation for large numbers
- bump version to 0.1.2
- add manpage for `mctc-convert`