### PR TITLE
Support atomic number in xyz format instead of symbols

### DIFF
--- a/src/mctc/io/read/xyz.f90
+++ b/src/mctc/io/read/xyz.f90
@@ -17,7 +17,7 @@ module mctc_io_read_xyz
    use mctc_env_error, only : error_type, fatal_error
    use mctc_io_convert, only : aatoau
    use mctc_io_structure, only : structure_type, new
-   use mctc_io_symbols, only : to_number, symbol_length
+   use mctc_io_symbols, only : to_number, to_symbol, symbol_length
    use mctc_io_utils, only : getline
    implicit none
    private
@@ -84,6 +84,14 @@ subroutine read_xyz(self, unit, error)
       end if
 
       iat = to_number(chdum)
+      if (iat <= 0) then
+         read(chdum, *, iostat=stat) iat
+         if (stat == 0) then
+            chdum = to_symbol(iat)
+         else
+            iat = 0
+         end if
+      end if
       if (iat > 0) then
          ii = ii+1
          sym(ii) = trim(chdum)

--- a/test/test_read_xyz.f90
+++ b/test/test_read_xyz.f90
@@ -36,6 +36,7 @@ subroutine collect_read_xyz(testsuite)
       & new_unittest("valid2-xyz", test_valid2_xyz), &
       & new_unittest("valid3-xyz", test_valid3_xyz), &
       & new_unittest("valid4-xyz", test_valid4_xyz), &
+      & new_unittest("valid5-xyz", test_valid5_xyz), &
       & new_unittest("invalid1-xyz", test_invalid1_xyz, should_fail=.true.), &
       & new_unittest("invalid2-xyz", test_invalid2_xyz, should_fail=.true.), &
       & new_unittest("invalid3-xyz", test_invalid3_xyz, should_fail=.true.), &
@@ -222,6 +223,43 @@ subroutine test_valid4_xyz(error)
    if (allocated(error)) return
 
 end subroutine test_valid4_xyz
+
+
+subroutine test_valid5_xyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "3", &
+      "WATER27, H2O", &
+      "8     1.1847029    1.1150792   -0.0344641 ", &
+      "1     0.4939088    0.9563767    0.6340089 ", &
+      "1     2.0242676    1.0811246    0.4301417 ", &
+      "3", &
+      "WATER27, H2O", &
+      "8    -1.1469443    0.0697649    1.1470196 ", &
+      "1    -1.2798308   -0.5232169    1.8902833 ", &
+      "1    -1.0641398   -0.4956693    0.3569250 "
+   rewind(unit)
+
+   call read_xyz(struc, unit, error)
+   if (.not.allocated(error)) then
+      call read_xyz(struc, unit, error)
+   end if
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 3, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 2, "Number of species does not match")
+   if (allocated(error)) return
+
+end subroutine test_valid5_xyz
 
 
 subroutine test_invalid1_xyz(error)


### PR DESCRIPTION
Support non-standard xyz input with atomic numbers instead of element symbols.

*Example*

```
  24

 6         -3.2624567556       -1.0740397867       -0.0000043734
 7         -2.2754344008       -0.0292896574        0.0000359020
 6         -0.9120851382       -0.2075386125       -0.0004880509
 6         -0.3749333299        1.0720554184       -0.0001564184
 7         -1.3570794708        1.9998111614        0.0003858762
 6         -2.4726070186        1.3013159995        0.0005402177
 1         -3.4474896946        1.7467507266        0.0010080843
 7          0.9669701935        1.2880523079       -0.0003374012
 6          1.8275740716        0.2107859932       -0.0000027214
 8          3.0306801280        0.3524772071        0.0002192165
 7          1.2570001166       -1.0570195560       -0.0000714961
 6         -0.0994181855       -1.3854842224       -0.0003307823
 8         -0.4879332634       -2.5400052828       -0.0002686844
 6          2.2118766147       -2.1535108670        0.0005997875
 1          1.6458936552       -3.0819689593        0.0002644601
 1          2.8452151680       -2.0921377814       -0.8838098923
 1          2.8439724684       -2.0920881626        0.8858951171
 6          1.4878336345        2.6373781425       -0.0003075130
 1          1.1373305002        3.1659703185       -0.8863920642
 1          1.1383298601        3.1656042978        0.8863960393
 1          2.5739975007        2.5744621695       -0.0008973695
 1         -3.8918239831       -1.0020514766       -0.8884978421
 1         -3.8928014413       -1.0010907638        0.8876971655
 1         -2.7437217829       -2.0316581902        0.0007283419
```