### PR TITLE
Implement system commands

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -31,6 +31,7 @@
 program main
    use, intrinsic :: iso_fortran_env, only : output_unit, error_unit, input_unit
    use mctc_env
+   use mctc_env_system, only : get_argument
    use mctc_io
    use mctc_io_symbols, only : to_symbol
    use mctc_version
@@ -112,38 +113,6 @@ subroutine version(unit)
       & prog_name, "version", version_string
 
 end subroutine version
-
-
-!> Obtain the command line argument at a given index
-subroutine get_argument(idx, arg)
-
-   !> Index of command line argument, range [0:command_argument_count()]
-   integer, intent(in) :: idx
-
-   !> Command line argument
-   character(len=:), allocatable, intent(out) :: arg
-
-   integer :: length, stat
-
-   call get_command_argument(idx, length=length, status=stat)
-   if (stat /= 0) then
-      return
-   endif
-
-   allocate(character(len=length) :: arg, stat=stat)
-   if (stat /= 0) then
-      return
-   endif
-
-   if (length > 0) then
-      call get_command_argument(idx, arg, status=stat)
-      if (stat /= 0) then
-         deallocate(arg)
-         return
-      end if
-   end if
-
-end subroutine get_argument
 
 
 subroutine get_arguments(input, input_format, output, output_format, normalize, &

--- a/app/main.f90
+++ b/app/main.f90
@@ -30,11 +30,10 @@
 !> in a similar manner.
 program main
    use, intrinsic :: iso_fortran_env, only : output_unit, error_unit, input_unit
-   use mctc_env
-   use mctc_env_system, only : get_argument
-   use mctc_io
-   use mctc_io_symbols, only : to_symbol
-   use mctc_version
+   use mctc_env, only : error_type, fatal_error, get_argument, wp
+   use mctc_io, only : structure_type, read_structure, write_structure, &
+      & filetype, get_filetype, to_symbol
+   use mctc_version, only : get_mctc_version
    implicit none
    character(len=*), parameter :: prog_name = "mctc-convert"
 

--- a/src/mctc/env.f90
+++ b/src/mctc/env.f90
@@ -16,6 +16,8 @@
 module mctc_env
    use mctc_env_accuracy, only : sp, dp, wp, i1, i2, i4, i8
    use mctc_env_error, only : error_type, fatal_error, mctc_stat
+   use mctc_env_system, only : get_argument, get_variable, &
+      & is_unix, is_windows
    implicit none
    public
 

--- a/src/mctc/env/CMakeLists.txt
+++ b/src/mctc/env/CMakeLists.txt
@@ -18,6 +18,7 @@ list(
   APPEND srcs
   "${dir}/accuracy.f90"
   "${dir}/error.f90"
+  "${dir}/system.f90"
   "${dir}/testing.f90"
 )
 

--- a/src/mctc/env/meson.build
+++ b/src/mctc/env/meson.build
@@ -15,5 +15,6 @@
 srcs += files(
   'accuracy.f90',
   'error.f90',
+  'system.f90',
   'testing.f90',
 )

--- a/src/mctc/env/system.f90
+++ b/src/mctc/env/system.f90
@@ -89,22 +89,22 @@ end subroutine get_variable
 
 
 !> Try to determine if we run on Windows and don't have POSIX compliance around
-function is_windows() result(windows)
+function is_windows()
 
    !> Operating system seems to be Windows
-   logical :: windows
+   logical :: is_windows
 
    character(len=:), allocatable :: tmp
 
-   windows = .false.
+   is_windows = .false.
    call get_variable('OS', tmp)
    if (allocated(tmp)) then
-      windows = index(tmp, 'Windows_NT') > 0
+      is_windows = index(tmp, 'Windows_NT') > 0
    end if
-   if (.not.windows) then
+   if (.not.is_windows) then
       call get_variable('OSTYPE', tmp)
       if (allocated(tmp)) then
-         windows = index(tmp, 'win') > 0 .or. index(tmp, 'msys') > 0
+         is_windows = index(tmp, 'win') > 0 .or. index(tmp, 'msys') > 0
       end if
    end if
 
@@ -112,14 +112,14 @@ end function is_windows
 
 
 !> Try to determine if we run on Unix and probably can rely on POSIX compliance
-function is_unix() result(unix)
+function is_unix()
 
    !> Operating system seems to be Unix
-   logical :: unix
+   logical :: is_unix
 
    character(len=:), allocatable :: tmp
 
-   unix = .not. is_windows()
+   is_unix = .not. is_windows()
 
 end function is_unix
 

--- a/src/mctc/env/system.f90
+++ b/src/mctc/env/system.f90
@@ -1,0 +1,127 @@
+! This file is part of mctc-lib.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+!> Module collecting commands to conveniently interface with system commands
+module mctc_env_system
+   implicit none
+   private
+
+   public :: get_argument, get_variable
+   public :: is_windows, is_unix
+
+
+contains
+
+
+!> Obtain the command line argument at a given index
+subroutine get_argument(idx, arg)
+
+   !> Index of command line argument, range [0:command_argument_count()]
+   integer, intent(in) :: idx
+
+   !> Command line argument
+   character(len=:), allocatable, intent(out) :: arg
+
+   integer :: length, stat
+
+   call get_command_argument(idx, length=length, status=stat)
+   if (stat /= 0) then
+      return
+   endif
+
+   allocate(character(len=length) :: arg, stat=stat)
+   if (stat /= 0) then
+      return
+   endif
+
+   if (length > 0) then
+      call get_command_argument(idx, arg, status=stat)
+      if (stat /= 0) then
+         deallocate(arg)
+         return
+      end if
+   end if
+
+end subroutine get_argument
+
+
+!> Obtain the value of an environment variable
+subroutine get_variable(var, val)
+
+   !> Name of variable
+   character(len=*), intent(in) :: var
+
+   !> Value of variable
+   character(len=:), allocatable, intent(out) :: val
+
+   integer :: length, stat
+
+   call get_environment_variable(var, length=length, status=stat)
+   if (stat /= 0) then
+      return
+   endif
+
+   allocate(character(len=length) :: val, stat=stat)
+   if (stat /= 0) then
+      return
+   endif
+
+   if (length > 0) then
+      call get_environment_variable(var, val, status=stat)
+      if (stat /= 0) then
+         deallocate(val)
+         return
+      end if
+   end if
+
+end subroutine get_variable
+
+
+!> Try to determine if we run on Windows and don't have POSIX compliance around
+function is_windows() result(windows)
+
+   !> Operating system seems to be Windows
+   logical :: windows
+
+   character(len=:), allocatable :: tmp
+
+   windows = .false.
+   call get_variable('OS', tmp)
+   if (allocated(tmp)) then
+      windows = index(tmp, 'Windows_NT') > 0
+   end if
+   if (.not.windows) then
+      call get_variable('OSTYPE', tmp)
+      if (allocated(tmp)) then
+         windows = index(tmp, 'win') > 0 .or. index(tmp, 'msys') > 0
+      end if
+   end if
+
+end function is_windows
+
+
+!> Try to determine if we run on Unix and probably can rely on POSIX compliance
+function is_unix() result(unix)
+
+   !> Operating system seems to be Unix
+   logical :: unix
+
+   character(len=:), allocatable :: tmp
+
+   unix = .not. is_windows()
+
+end function is_unix
+
+
+end module mctc_env_system

--- a/src/mctc/io.f90
+++ b/src/mctc/io.f90
@@ -27,6 +27,7 @@ module mctc_io
    use mctc_io_filetype, only : filetype, get_filetype
    use mctc_io_read, only : read_structure
    use mctc_io_structure, only : structure_type, new_structure, new
+   use mctc_io_symbols, only : to_symbol, to_number
    use mctc_io_write, only : write_structure
    implicit none
    private
@@ -34,6 +35,7 @@ module mctc_io
    public :: filetype, get_filetype
    public :: read_structure, write_structure
    public :: structure_type, new_structure, new
+   public :: to_symbol, to_number
 
 
 contains

--- a/test/main.f90
+++ b/test/main.f90
@@ -15,6 +15,7 @@
 !> Driver for unit testing
 program tester
    use, intrinsic :: iso_fortran_env, only : error_unit
+   use mctc_env_system, only : get_argument
    use mctc_env_testing, only : run_testsuite, new_testsuite, testsuite_type, &
       & select_suite, run_selected
    use test_math, only : collect_math
@@ -98,41 +99,6 @@ program tester
       write(error_unit, '(i0, 1x, a)') stat, "test(s) failed!"
       error stop 1
    end if
-
-
-contains
-
-
-!> Obtain the command line argument at a given index
-subroutine get_argument(idx, arg)
-
-   !> Index of command line argument, range [0:command_argument_count()]
-   integer, intent(in) :: idx
-
-   !> Command line argument
-   character(len=:), allocatable, intent(out) :: arg
-
-   integer :: length, stat
-
-   call get_command_argument(idx, length=length, status=stat)
-   if (stat /= 0) then
-      return
-   endif
-
-   allocate(character(len=length) :: arg, stat=stat)
-   if (stat /= 0) then
-      return
-   endif
-
-   if (length > 0) then
-      call get_command_argument(idx, arg, status=stat)
-      if (stat /= 0) then
-         deallocate(arg)
-         return
-      end if
-   end if
-
-end subroutine get_argument
 
 
 end program tester


### PR DESCRIPTION
- new `mctc_env_system` module (reexported in `mctc_env`)
- allow retrieving of command line arguments as deferred length characters
- allow retrieving of environment variables as deferred length characters
- simple detection logic to distinguish Unix/Windows systems