### PR TITLE
Allow usage of template input to amend geometry information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ get_directory_property(is-subproject PARENT_DIRECTORY)
 project(
   "mctc-lib"
   LANGUAGES "Fortran"
-  VERSION "0.2.0"
+  VERSION "0.2.1"
   DESCRIPTION "Modular computation tool chain"
 )
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "mctc-lib"
-version = "0.2.0"
+version = "0.2.1"
 license = "Apache-2.0"
 maintainer = ["@awvwgk"]
 author = ["Sebastian Ehlert"]

--- a/man/mctc-convert.1.adoc
+++ b/man/mctc-convert.1.adoc
@@ -13,6 +13,9 @@ mctc-convert - Convert between supported input formats of the tool chain library
 
 Read structure from input file and writes it to output file.
 The format is determined by the file extension or the format hint.
+The input structure can be read from standard input by providing - as argument.
+Similarly, the output structure can be written to standard output with - as argument.
+Standard input and standard output should be combined with a format hint option.
 
 Supported formats:
 
@@ -35,6 +38,16 @@ Hint for the format of the output file
 
 *--normalize*::
 Normalize all element symbols to capitalized format
+
+*--template* _file_::
+File to use as template to fill in meta data (useful to add back SDF or PDB annotions).
+Transfers lattice, periodicity, comments and format specific annotations from the template
+to the input structure.
+If the standard input, -, is provided the template structure will
+be read _before_ the input structure.
+
+*--template-format* _format_::
+Hint for the format of the template file (only used if template file name is provided)
 
 *--version*::
 Print program version and exit

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@
 project(
   'mctc-lib',
   'fortran',
-  version: '0.2.0',
+  version: '0.2.1',
   license: 'Apache-2.0',
   meson_version: '>=0.53',
   default_options: [

--- a/src/mctc/io/read/pdb.f90
+++ b/src/mctc/io/read/pdb.f90
@@ -97,7 +97,7 @@ subroutine read_pdb(self, unit, error)
    end if
 
    call new(self, sym(:iatom), xyz(:, :iatom))
-   !self%pdb = pdb(:iatom)
+   self%pdb = pdb(:iatom)
    self%charge = sum(pdb(:iatom)%charge)
 
    if (.not.all(self%num > 0)) then

--- a/src/mctc/version.f90
+++ b/src/mctc/version.f90
@@ -21,10 +21,10 @@ module mctc_version
 
 
    !> String representation of the mctc-lib version
-   character(len=*), parameter :: mctc_version_string = "0.2.0"
+   character(len=*), parameter :: mctc_version_string = "0.2.1"
 
    !> Numeric representation of the mctc-lib version
-   integer, parameter :: mctc_version_compact(3) = [0, 2, 0]
+   integer, parameter :: mctc_version_compact(3) = [0, 2, 1]
 
 
 contains


### PR DESCRIPTION
- transfer lattice, periodicity, bonds and other annotations
- the template structure is read before the input structure from STDIN
- error if template and input structure mismatch in the number of atoms