### PR TITLE
openmp when subproject

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -49,3 +49,8 @@ elif fc_id == 'flang'
     language: 'fortran',
   )
 endif
+
+if fc_id == 'intel'
+  omp_dep = dependency('openmp')
+  lib_deps += omp_dep
+endif


### PR DESCRIPTION
This averts a linking error (below) when building dftd4 with Intel and OpenMP. It's probably incomplete because not checking value of OpenMP option. But that's an option of the parent project, not this one, so you'll know better how these projects should hold together.

```
/psi/gits/dftd4/_build /psi/gits/dftd4
The Meson build system
Version: 0.57.1
Source dir: /psi/gits/dftd4
Build dir: /psi/gits/dftd4/_build
Build type: native build
Project name: dftd4
Project version: 3.1.0
Fortran compiler for the host machine: ifort (intel 19.0.4.243 "ifort (IFORT) 19.0.4.243 20190416")
Fortran linker for the host machine: ifort ld.bfd 2.25.1-22
ifort: command line warning #10006: ignoring unknown option '-fno-plt'
ifort: command line warning #10006: ignoring unknown option '-ffunction-sections'
ifort: command line warning #10006: ignoring unknown option '-pipe'
ifort: warning #10193: -vec is default; use -x and -ax to configure vectorization
Host machine cpu family: x86_64
Host machine cpu: x86_64
C compiler for the host machine: icc (intel 19.0.4.243 "icc (ICC) 19.0.4.243 20190416")
C linker for the host machine: icc ld.bfd 2.25.1-22
Run-time dependency OpenMP found: YES 5.0-revision1
Library mkl_rt found: YES
Library ifcore found: YES
Cloning into 'mctc-lib'...
remote: Enumerating objects: 830, done.
remote: Counting objects: 100% (830/830), done.
remote: Compressing objects: 100% (225/225), done.
remote: Total 3116 (delta 740), reused 661 (delta 599), pack-reused 2286
Receiving objects: 100% (3116/3116), 1.53 MiB | 0 bytes/s, done.
Resolving deltas: 100% (2742/2742), done.
Already on 'main'

|Executing subproject mctc-lib method meson 
|
|Project name: mctc-lib
|Project version: 0.2.1
|Fortran compiler for the host machine: ifort (intel 19.0.4.243 "ifort (IFORT) 19.0.4.243 20190416")
|Fortran linker for the host machine: ifort ld.bfd 2.25.1-22
|Build targets in project: 3
|Subproject mctc-lib finished.


|Executing subproject multicharge method meson 
|
|Project name: multicharge
|Project version: 0.1.0
|Fortran compiler for the host machine: ifort (intel 19.0.4.243 "ifort (IFORT) 19.0.4.243 20190416")
|Fortran linker for the host machine: ifort ld.bfd 2.25.1-22
|Dependency openmp found: YES 5.0-revision1 (cached)
|Library mkl_rt found: YES
|
||Executing subproject mstore method meson 
||
||Project name: mstore
||Project version: 0.1.2
||Fortran compiler for the host machine: ifort (intel 19.0.4.243 "ifort (IFORT) 19.0.4.243 20190416")
||Fortran linker for the host machine: ifort ld.bfd 2.25.1-22
||Build targets in project: 7
||Subproject mstore finished.
|
|Build targets in project: 8
|Subproject multicharge finished.

Program python3 (cffi) found: YES (/home/psilocaluser/toolchainconda/envs/py39/bin/python3) modules: cffi
Found pkg-config: /usr/bin/pkg-config (0.27.1)
Dependency python found: YES (pkgconfig)
Configuring _libdftd4.h with command
Configuring _libdftd4.c with command
Program asciidoctor found: YES (/home/psilocaluser/toolchainconda/envs/py39/bin/asciidoctor)
Configuring dftd4.1 with command
Build targets in project: 15

dftd4 3.1.0

  Subprojects
    mctc-lib   : YES
    mstore     : YES
    multicharge: YES

Option buildtype is: release [default: debugoptimized]
Found ninja-1.10.2 at /home/psilocaluser/toolchainconda/envs/py39/bin/ninja
[67/144] Linking target subprojects/mctc-lib/app/mctc-convert
FAILED: subprojects/mctc-lib/app/mctc-convert 
ifort  -o subprojects/mctc-lib/app/mctc-convert subprojects/mctc-lib/app/mctc-convert.p/main.f90.o -L/home/psilocaluser/toolchainconda/envs/py39/lib -Wl,--as-needed -Wl,--no-undefined -Wl,-O1 -Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -Wl,-rpath,/home/psilocaluser/toolchainconda/envs/py39/lib -Wl,-rpath-link,/home/psilocaluser/toolchainconda/envs/py39/lib -Wl,--start-group subprojects/mctc-lib/libmctc-lib.a -Wl,--end-group
subprojects/mctc-lib/app/mctc-convert.p/main.f90.o: In function `MAIN__':
main.f90:(.text+0x3d): undefined reference to `__kmpc_begin'
main.f90:(.text+0xc2c): undefined reference to `__kmpc_end'
[79/144] Compiling Fortran object subprojects/mstore/libmstore.a.p/src_mstore_amino20x4.f90.o
ninja: build stopped: subcommand failed.
```