### PR TITLE
Bump version to 0.2.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.14)
 project(
   "mctc-lib"
   LANGUAGES "Fortran"
-  VERSION "0.2.3"
+  VERSION "0.2.4"
   DESCRIPTION "Modular computation tool chain"
 )
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "mctc-lib"
-version = "0.2.3"
+version = "0.2.4"
 license = "Apache-2.0"
 maintainer = ["@awvwgk"]
 author = ["Sebastian Ehlert"]

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@
 project(
   'mctc-lib',
   'fortran',
-  version: '0.2.3',
+  version: '0.2.4',
   license: 'Apache-2.0',
   meson_version: '>=0.55',
   default_options: [

--- a/src/mctc/version.F90
+++ b/src/mctc/version.F90
@@ -23,10 +23,10 @@ module mctc_version
 
 
    !> String representation of the mctc-lib version
-   character(len=*), parameter :: mctc_version_string = "0.2.3"
+   character(len=*), parameter :: mctc_version_string = "0.2.4"
 
    !> Numeric representation of the mctc-lib version
-   integer, parameter :: mctc_version_compact(3) = [0, 2, 3]
+   integer, parameter :: mctc_version_compact(3) = [0, 2, 4]
 
 
    !> With support for JSON


### PR DESCRIPTION
Changelog

* Update Turbomole reader (https://github.com/grimme-lab/mctc-lib/pull/18)
* Ensure module output directory is generated in configure stage (https://github.com/grimme-lab/mctc-lib/pull/19)
* Update testing workflow (https://github.com/grimme-lab/mctc-lib/pull/21)
* Don't require element symbols to match symbol_length (https://github.com/grimme-lab/mctc-lib/pull/22)
* Add support for writing QCSchema JSON (https://github.com/grimme-lab/mctc-lib/pull/23)
* Add support for reading QCSchema JSON (https://github.com/grimme-lab/mctc-lib/pull/24)