### PR TITLE
Improve error reporting for input readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ type(error_type), allocatable :: error
 
 call read_structure(mol, "input.xyz", error)
 if (allocated(error)) then
-   print '("[Error]", 1x, a)', error%message
+   print '(a)', error%message
    error stop
 end if
 ```
@@ -164,13 +164,71 @@ type(error_type), allocatable :: error
 
 call write_structure(mol, "output.xyz", error)
 if (allocated(error)) then
-   print '("[Error]", 1x, a)', error%message
+   print '(a)', error%message
    error stop
 end if
 ```
 
 The [``mctc-convert``](man/mctc-convert.1.adoc) program provides a chained reader and writer call to act as a geometry file converter.
 Checkout the implementation in [``app/main.f90``](app/main.f90).
+
+
+## Error reporting
+
+The geometry input readers try to be provide helpful error messages, no user should be left alone with an error message like *invalid input*.
+Unclear error messages are considered a bug in *mctc-lib*, if you struggle to make sense of a reported error, file us an issue and we will make the report better.
+
+**How can helpful error messages look like?**
+Here are some examples.
+
+1. negative number of atoms declared in xyz file
+
+```
+Error: Impossible number of atoms provided
+ --> struc.xyz:1:1-2
+  |
+1 | -3
+  | ^^ expected positive integer value
+  |
+```
+
+2. total charge is not specified as integer
+
+```
+Error: Cannot read eht entry
+  --> struc.coord:18:13-15
+   |
+18 | $eht charge=one unpaired=0
+   |             ^^^ expected integer value
+   |
+```
+
+3. a fixed width entry contains an incorrect value
+
+```
+Error: Cannot read charges
+  --> struc.mol:29:23-25
+   |
+29 | M  CHG  3   1   1   3   b   2  -1
+   |                       ^^^ expected integer value
+   |
+```
+
+4. Turbomole input with confliciting data groups
+
+```
+Error: Conflicting lattice and cell groups
+  --> struc.coord:37:1-5
+   |
+35 | $lattice angs
+   | -------- lattice first defined here
+   :
+37 | $cell angs
+   | ^^^^^ conflicting cell group
+   |
+```
+
+We try to retain as much information as possible when displaying the error message to make it easy to fix the offending part in the input.
 
 
 ## License

--- a/src/mctc/io/read/aims.f90
+++ b/src/mctc/io/read/aims.f90
@@ -20,7 +20,7 @@ module mctc_io_read_aims
    use mctc_io_symbols, only : symbol_length, to_number
    use mctc_io_structure, only : structure_type, new
    use mctc_io_utils, only : next_line, token_type, next_token, io_error, filename, &
-      read_token, to_string
+      read_next_token, to_string
    implicit none
    private
 
@@ -70,11 +70,11 @@ subroutine read_aims(mol, unit, error)
       select case(line(token%first:token%last))
       case("atom", "atom_frac")
          is_frac = token%last - token%first + 1 > 4
-         call read_token(line, pos, token, x, stat)
+         call read_next_token(line, pos, token, x, stat)
          if (stat == 0) &
-            call read_token(line, pos, token, y, stat)
+            call read_next_token(line, pos, token, y, stat)
          if (stat == 0) &
-            call read_token(line, pos, token, z, stat)
+            call read_next_token(line, pos, token, z, stat)
          if (stat == 0) &
             call next_token(line, pos, token)
          if (stat /= 0) then
@@ -84,11 +84,12 @@ subroutine read_aims(mol, unit, error)
          end if
 
          if (iat >= size(sym)) call resize(sym)
-         if (iat >= size(xyz)) call resize(xyz)
-         if (iat >= size(abc)) call resize(abc)
+         if (iat >= size(xyz, 2)) call resize(xyz)
+         if (iat >= size(abc, 2)) call resize(abc)
          if (iat >= size(frac)) call resize(frac)
          iat = iat + 1
 
+         token%last = min(token%last, token%first + symbol_length - 1)
          sym(iat) = line(token%first:token%last)
          if (to_number(sym(iat)) == 0) then
             call io_error(error, "Cannot map symbol to atomic number", &
@@ -109,11 +110,11 @@ subroutine read_aims(mol, unit, error)
                & line, token, filename(unit), lnum, "forth lattice vector found")
             exit
          end if
-         call read_token(line, pos, token, x, stat)
+         call read_next_token(line, pos, token, x, stat)
          if (stat == 0) &
-            call read_token(line, pos, token, y, stat)
+            call read_next_token(line, pos, token, y, stat)
          if (stat == 0) &
-            call read_token(line, pos, token, z, stat)
+            call read_next_token(line, pos, token, z, stat)
          if (stat /= 0) then
             call io_error(error, "Cannot read lattice vectors", &
                & line, token, filename(unit), lnum, "expected real value")

--- a/src/mctc/io/read/ctfile.f90
+++ b/src/mctc/io/read/ctfile.f90
@@ -19,7 +19,8 @@ module mctc_io_read_ctfile
    use mctc_io_structure, only : structure_type, new
    use mctc_io_structure_info, only : sdf_data, structure_info
    use mctc_io_symbols, only : to_number, symbol_length
-   use mctc_io_utils, only : getline
+   use mctc_io_utils, only : next_line, token_type, next_token, io_error, filename, &
+      read_token, to_string
    implicit none
    private
 
@@ -41,14 +42,15 @@ subroutine read_sdf(self, unit, error)
    type(error_type), allocatable, intent(out) :: error
 
    character(len=:), allocatable :: line
-   integer :: stat
+   integer :: stat, lnum, pos
 
    call read_molfile(self, unit, error)
    if (allocated(error)) return
 
+   lnum = 0
    stat = 0
    do while(stat == 0)
-      call getline(unit, line, stat)
+      call next_line(unit, line, pos, lnum, stat)
       if (index(line, '$$$$') == 1) exit
    end do
    if (stat /= 0) then
@@ -73,37 +75,44 @@ subroutine read_molfile(self, unit, error)
    character(len=:), allocatable :: line
    character(len=:), allocatable :: comment
    integer :: i, iatom, jatom, ibond, btype, atomtype
-   integer :: stat, length, charge(2, 15)
-   integer :: number_of_atoms, number_of_bonds, number_of_atom_lists, &
-      &       chiral_flag, number_of_stext_entries, i999
-   integer :: list4(4), list12(12)
+   integer :: stat, length, charge(2, 15), lnum, pos
+   integer :: number_of_atoms, number_of_bonds
+   integer :: list7(7), list12(12)
    real(wp) :: x, y, z
    character(len=2) :: sdf_dim
    character(len=3) :: symbol
    character(len=5) :: v2000
    integer, parameter :: ccc_to_charge(0:7) = [0, +3, +2, +1, 0, -1, -2, -3]
    logical :: two_dim
+   type(token_type) :: token
    character(len=symbol_length), allocatable :: sym(:)
    type(sdf_data), allocatable :: sdf(:)
    type(structure_info) :: info
    real(wp), allocatable :: xyz(:, :)
    integer, allocatable :: bond(:, :)
 
+   lnum = 0
    two_dim = .false.
 
-   call getline(unit, comment, stat)
-   call getline(unit, line, stat)
+   call next_line(unit, comment, pos, lnum, stat)
+   call next_line(unit, line, pos, lnum, stat)
    read(line, '(20x, a2)', iostat=stat) sdf_dim
    if (stat == 0) then
       two_dim = sdf_dim == '2D' .or. sdf_dim == '2d'
    end if
-   call getline(unit, line, stat)
-   call getline(unit, line, stat)
-   read(line, '(3i3, 3x, 2i3, 12x, i3, 1x, a5)', iostat=stat) &
-      & number_of_atoms, number_of_bonds, number_of_atom_lists, &
-      & chiral_flag, number_of_stext_entries, i999, v2000
+   call next_line(unit, line, pos, lnum, stat)
+   call next_line(unit, line, pos, lnum, stat)
+   if (stat == 0) then
+      token = token_type(1, 3)
+      call read_token(line, token, number_of_atoms, stat)
+   end if
+   if (stat == 0) then
+      token = token_type(4, 6)
+      call read_token(line, token, number_of_bonds, stat)
+   end if
    if (stat /= 0) then
-      call fatal_error(error, "Cannot read header of molfile")
+      call io_error(error, "Cannot read header of molfile", &
+         & line, token, filename(unit), lnum, "expected integer value")
       return
    end if
 
@@ -112,20 +121,45 @@ subroutine read_molfile(self, unit, error)
    allocate(sym(number_of_atoms))
 
    do iatom = 1, number_of_atoms
-      call getline(unit, line, stat)
-      read(line, '(3f10.4, 1x, a3, i2, 11i3)', iostat=stat) &
-         & x, y, z, symbol, list12
+      call next_line(unit, line, pos, lnum, stat)
+      if (stat == 0) then
+         token = token_type(1, 10)
+         call read_token(line, token, x, stat)
+      end if
+      if (stat == 0) then
+         token = token_type(11, 20)
+         call read_token(line, token, y, stat)
+      end if
+      if (stat == 0) then
+         token = token_type(21, 30)
+         call read_token(line, token, z, stat)
+      end if
+      if (len(line) >= 34) then
+         symbol = line(32:34)
+      end if
+      if (stat == 0) then
+         token = token_type(35, 36)
+         call read_token(line, token, list12(1), stat)
+      end if
+      do i = 1, 11
+         if (stat == 0) then
+            token = token_type(34 + i*3, 36 + i*3)
+            call read_token(line, token, list12(i+1), stat)
+         end if
+      end do
       if (stat /= 0) then
-         call fatal_error(error, "Cannot read coordinates from connection table")
+         call io_error(error, "Cannot read coordinates from connection table", &
+            & line, token, filename(unit), lnum, "unexpected value")
          return
       end if
       atomtype = to_number(symbol)
       if (atomtype == 0) then
-         call fatal_error(error, "Unknown atom type '"//trim(symbol)//"' in connection table")
+         call io_error(error, "Cannot map symbol to atomic number", &
+            & line, token_type(32, 34), filename(unit), lnum, "unknown element")
          return
       end if
       xyz(:, iatom) = [x, y, z] * aatoau
-      sym(iatom) = trim(symbol)
+      sym(iatom) = symbol
       sdf(iatom)%isotope = list12(1)
       sdf(iatom)%charge = ccc_to_charge(list12(2)) ! drop doublet radical
       sdf(iatom)%hydrogens = list12(4)
@@ -134,22 +168,47 @@ subroutine read_molfile(self, unit, error)
 
    allocate(bond(3, number_of_bonds))
    do ibond = 1, number_of_bonds
-      call getline(unit, line, stat)
-      read(line, '(7i3)', iostat=stat) &
-         & iatom, jatom, btype, list4
+      call next_line(unit, line, pos, lnum, stat)
+      do i = 1, 7
+         if (stat == 0) then
+            token = token_type(i*3 - 2, i*3)
+            call read_token(line, token, list7(i), stat)
+         end if
+      end do
       if (stat /= 0) then
-         call fatal_error(error, "Cannot read topology from connection table")
+         call io_error(error, "Cannot read topology from connection table", &
+            & line, token, filename(unit), lnum, "unexpected value")
          return
       end if
+      iatom = list7(1)
+      jatom = list7(2)
+      btype = list7(3)
       bond(:, ibond) = [iatom, jatom, btype]
    end do
 
    do while(stat == 0)
-      call getline(unit, line, stat)
+      call next_line(unit, line, pos, lnum, stat)
       if (index(line, 'M  END') == 1) exit
       if (index(line, 'M  CHG') == 1) then
+         token = token_type(7, 9)
          read(line(7:9), *) length
-         read(line(10:), '(*(1x, i3, 1x, i3))') (charge(:, i), i=1, length)
+         call read_token(line, token, length, stat)
+         if (stat == 0) then
+            do i = 1, length
+               if (stat /= 0) exit
+               token = token_type(3 + i*8, 5 + i*8)
+               call read_token(line, token, charge(1, i), stat)
+               if (charge(1, i) > number_of_atoms .or. charge(1, i) < 1) stat = 1
+               if (stat /= 0) exit
+               token = token_type(7 + i*8, 9 + i*8)
+               call read_token(line, token, charge(2, i), stat)
+            end do
+         end if
+         if (stat /= 0) then
+            call io_error(error, "Cannot read charges", &
+               & line, token, filename(unit), lnum, "expected integer value")
+            return
+         end if
          do i = 1, length
             sdf(charge(1, i))%charge = charge(2, i)
          end do

--- a/src/mctc/io/read/genformat.f90
+++ b/src/mctc/io/read/genformat.f90
@@ -14,13 +14,13 @@
 
 module mctc_io_read_genformat
    use mctc_env_accuracy, only : wp
-   use mctc_env_error, only : error_type, fatal_error
+   use mctc_env_error, only : error_type
    use mctc_io_convert, only : aatoau
    use mctc_io_structure, only : structure_type, new
    use mctc_io_structure_info, only : structure_info
    use mctc_io_symbols, only : to_number, symbol_length
    use mctc_io_utils, only : next_line, token_type, next_token, io_error, filename, &
-      read_token, to_string
+      read_next_token, to_string
    implicit none
    private
 
@@ -54,7 +54,7 @@ subroutine read_genformat(mol, unit, error)
 
    lnum = 0
    call advance_line(unit, line, pos, lnum, stat)
-   call read_token(line, pos, token, natoms, stat)
+   call read_next_token(line, pos, token, natoms, stat)
    if (stat /= 0 .or. natoms < 1) then
       call io_error(error, "Could not read number of atoms", &
          & line, token, filename(unit), lnum, "expected integer value")
@@ -102,15 +102,15 @@ subroutine read_genformat(mol, unit, error)
       token = token_type(0, 0)
       call advance_line(unit, line, pos, lnum, stat)
       if (stat == 0) &
-         call read_token(line, pos, token, dummy, stat)
+         call read_next_token(line, pos, token, dummy, stat)
       if (stat == 0) &
-         call read_token(line, pos, token, isp, stat)
+         call read_next_token(line, pos, token, isp, stat)
       if (stat == 0) &
-         call read_token(line, pos, token, coord(1), stat)
+         call read_next_token(line, pos, token, coord(1), stat)
       if (stat == 0) &
-         call read_token(line, pos, token, coord(2), stat)
+         call read_next_token(line, pos, token, coord(2), stat)
       if (stat == 0) &
-         call read_token(line, pos, token, coord(3), stat)
+         call read_next_token(line, pos, token, coord(3), stat)
       if (stat /= 0) then
          call io_error(error, "Cannot read coordinates", &
             & line, token, filename(unit), lnum, "unexpected value")
@@ -134,11 +134,11 @@ subroutine read_genformat(mol, unit, error)
       do ilat = 1, 3
          call advance_line(unit, line, pos, lnum, stat)
          if (stat == 0) &
-            call read_token(line, pos, token, coord(1), stat)
+            call read_next_token(line, pos, token, coord(1), stat)
          if (stat == 0) &
-            call read_token(line, pos, token, coord(2), stat)
+            call read_next_token(line, pos, token, coord(2), stat)
          if (stat == 0) &
-            call read_token(line, pos, token, coord(3), stat)
+            call read_next_token(line, pos, token, coord(3), stat)
          if (stat /= 0) then
             call io_error(error, "Cannot read lattice vector", &
                & line, token, filename(unit), lnum, "expected real value")

--- a/src/mctc/io/read/vasp.f90
+++ b/src/mctc/io/read/vasp.f90
@@ -21,7 +21,7 @@ module mctc_io_read_vasp
    use mctc_io_structure_info, only : structure_info
    use mctc_io_symbols, only : to_number, symbol_length
    use mctc_io_utils, only : next_line, token_type, next_token, io_error, filename, &
-      read_token, to_string
+      read_next_token, to_string
    implicit none
    private
 
@@ -77,7 +77,7 @@ subroutine read_vasp(self, unit, error)
       call fatal_error(error, "Unexpected end of input encountered")
       return
    end if
-   call read_token(line, pos, token, ddum, stat)
+   call read_next_token(line, pos, token, ddum, stat)
    if (stat /= 0) then
       call io_error(error, "Cannot read scaling factor", &
          & line, token, filename(unit), lnum, "expected real value")
@@ -93,11 +93,11 @@ subroutine read_vasp(self, unit, error)
          call fatal_error(error, "Unexpected end of lattice vectors encountered")
          return
       end if
-      call read_token(line, pos, token, latvec(1), stat)
+      call read_next_token(line, pos, token, latvec(1), stat)
       if (stat == 0) &
-         call read_token(line, pos, token, latvec(2), stat)
+         call read_next_token(line, pos, token, latvec(2), stat)
       if (stat == 0) &
-         call read_token(line, pos, token, latvec(3), stat)
+         call read_next_token(line, pos, token, latvec(3), stat)
       if (stat /= 0) then
          call io_error(error, "Cannot read lattice vectors from input", &
             & line, token, filename(unit), lnum, "expected real value")
@@ -181,11 +181,11 @@ subroutine read_vasp(self, unit, error)
          call fatal_error(error, "Unexpected end of geometry encountered")
          return
       end if
-      call read_token(line, pos, token, coord(1), stat)
+      call read_next_token(line, pos, token, coord(1), stat)
       if (stat == 0) &
-         call read_token(line, pos, token, coord(2), stat)
+         call read_next_token(line, pos, token, coord(2), stat)
       if (stat == 0) &
-         call read_token(line, pos, token, coord(3), stat)
+         call read_next_token(line, pos, token, coord(3), stat)
       if (stat /= 0) then
          call io_error(error, "Cannot read geometry from input", &
             & line, token, filename(unit), lnum, "expected real value")

--- a/src/mctc/io/read/xyz.f90
+++ b/src/mctc/io/read/xyz.f90
@@ -19,7 +19,7 @@ module mctc_io_read_xyz
    use mctc_io_structure, only : structure_type, new
    use mctc_io_symbols, only : to_number, to_symbol, symbol_length
    use mctc_io_utils, only : next_line, token_type, next_token, io_error, filename, &
-      read_token, to_string
+      read_next_token, to_string
    implicit none
    private
 
@@ -52,10 +52,10 @@ subroutine read_xyz(self, unit, error)
    lnum = 0
 
    call next_line(unit, fline, pos, lnum, stat)
-   call read_token(fline, pos, tnat, n, stat)
+   call read_next_token(fline, pos, tnat, n, stat)
    if (stat /= 0) then
       call io_error(error, "Could not read number of atoms", &
-         & fline, tnat, filename(unit), lnum, "expected integer vale")
+         & fline, tnat, filename(unit), lnum, "expected integer value")
       return
    end if
 
@@ -71,7 +71,8 @@ subroutine read_xyz(self, unit, error)
    ! next record is a comment
    call next_line(unit, comment, pos, lnum, stat)
    if (stat /= 0) then
-      call fatal_error(error, "Unexpected end of file")
+      call io_error(error, "Unexpected end of file", &
+         & "", token_type(0, 0), filename(unit), lnum+1, "expected value")
       return
    end if
 
@@ -80,16 +81,17 @@ subroutine read_xyz(self, unit, error)
       call next_line(unit, line, pos, lnum, stat)
       if (is_iostat_end(stat)) exit
       if (stat /= 0) then
-         call fatal_error(error, "Could not read geometry from xyz file")
+         call io_error(error, "Could not read geometry from xyz file", &
+            & "", token_type(0, 0), filename(unit), lnum+1, "expected value")
          return
       end if
       call next_token(line, pos, tsym)
       if (stat == 0) &
-         call read_token(line, pos, token, x, stat)
+         call read_next_token(line, pos, token, x, stat)
       if (stat == 0) &
-         call read_token(line, pos, token, y, stat)
+         call read_next_token(line, pos, token, y, stat)
       if (stat == 0) &
-         call read_token(line, pos, token, z, stat)
+         call read_next_token(line, pos, token, z, stat)
       if (stat /= 0) then
          call io_error(error, "Could not parse coordinates from xyz file", &
             & line, token, filename(unit), lnum, "expected real value")

--- a/test/test_read.f90
+++ b/test/test_read.f90
@@ -168,7 +168,7 @@ subroutine test_sdf(error)
       "  6 12  1  0  0  0  0", &
       "  7  2  1  0  0  0  0", &
       "  7 13  1  0  0  0  0", &
-      "M  CHG  1  5  1", &
+      "M  CHG  1   5   1", &
       "M  END", &
       ">  <total energy / Eh>", &
       "-18.421705869411", &

--- a/test/test_read_ctfile.f90
+++ b/test/test_read_ctfile.f90
@@ -37,11 +37,13 @@ subroutine collect_read_ctfile(testsuite)
       & new_unittest("invalid1-mol", test_invalid1_mol, should_fail=.true.), &
       & new_unittest("invalid2-mol", test_invalid2_mol, should_fail=.true.), &
       & new_unittest("invalid3-mol", test_invalid3_mol, should_fail=.true.), &
+      & new_unittest("invalid4-mol", test_invalid4_mol, should_fail=.true.), &
       & new_unittest("valid1-sdf", test_valid1_sdf), &
       & new_unittest("valid2-sdf", test_valid2_sdf), &
       & new_unittest("invalid1-sdf", test_invalid1_sdf, should_fail=.true.), &
       & new_unittest("invalid2-sdf", test_invalid2_sdf, should_fail=.true.), &
-      & new_unittest("invalid3-sdf", test_invalid3_sdf, should_fail=.true.) &
+      & new_unittest("invalid3-sdf", test_invalid3_sdf, should_fail=.true.), &
+      & new_unittest("invalid4-sdf", test_invalid4_sdf, should_fail=.true.) &
       & ]
 
 end subroutine collect_read_ctfile
@@ -306,6 +308,54 @@ subroutine test_invalid3_mol(error)
    close(unit)
 
 end subroutine test_invalid3_mol
+
+
+subroutine test_invalid4_mol(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "", &
+      "  Mrv1823 10191918163D          ", &
+      "", &
+      " 12 12  0  0  0  0            999 V2000", &
+      "   -0.0090   -0.0157   -0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "   -0.7131    1.2038   -0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "    1.3990   -0.0157   -0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "   -0.0090    2.4232   -0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "    2.1031    1.2038   -0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "    1.3990    2.4232    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "   -0.5203   -0.9011   -0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "   -1.7355    1.2038    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "    1.9103   -0.9011    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "   -0.5203    3.3087    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "    3.1255    1.2038    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "    1.9103    3.3087   -0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "  2  1  4  0  0  0  0", &
+      "  3  1  4  0  0  0  0", &
+      "  4  2  4  0  0  0  0", &
+      "  5  3  4  0  0  0  0", &
+      "  6  4  4  0  0  0  0", &
+      "  6  5  4  0  0  0  0", &
+      "  1  7  1  0  0  0  0", &
+      "  2  8  1  0  0  0  0", &
+      "  3  9  1  0  0  0  0", &
+      "  4 10  1  0  0  0  0", &
+      "  5 11  1  0  0  0  0", &
+      "  6 12  1  0  0  0  0", &
+      "M  CHG  3   1   1   3   b   2  -1", &
+      "M  END"
+   rewind(unit)
+
+   call read_molfile(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid4_mol
 
 
 subroutine test_valid1_sdf(error)
@@ -594,6 +644,62 @@ subroutine test_invalid3_sdf(error)
    if (allocated(error)) return
 
 end subroutine test_invalid3_sdf
+
+
+subroutine test_invalid4_sdf(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "", &
+      "  xtb     08072014173D", &
+      "", &
+      " 13 13  0     0  0            999 V2000", &
+      "    1.4896   -2.2438   -0.0275 O   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "    0.8475   -1.2058   -0.0075 C   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "    1.4981    0.0466    0.2360 C   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "    0.7744    1.2240    0.2564 C   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "   -0.5681    1.2354    0.0512 C   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "   -1.3469   -0.0099   -0.2052 C   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "   -0.5125   -1.2225   -0.2193 N   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "    2.5680    0.0344    0.3998 H   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "    1.2958    2.1567    0.4406 H   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "   -1.0960    2.1819    0.0742 H   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "   -1.8599    0.0606   -1.1755 H   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "   -2.1168   -0.1374    0.5699 H   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "   -0.9728   -2.1202   -0.3930 H   0  0  0  0  0  0  0  0  0  0  0  0", &
+      "  1  2  2  0  0  0  0", &
+      "  2  3  1  0  0  0  0", &
+      "  3  4  2  0  0  0  0", &
+      "  3  8  1  0  0  0  0", &
+      "  4  5  1  0  0  0  0", &
+      "  4  9  1  0  0  0  0", &
+      "  5  6  1  0  0  0  0", &
+      "  5 10  1  0  0  0  0", &
+      "  6  7  1  0  0  0  0", &
+      "  6 11  1  0  0  0  0", &
+      "  6 12  1  0  0  0  0", &
+      "  7  2  1  0  0  0  0", &
+      "  7 13  1  0  0  0  0", &
+      "M  CHG  1 5 1", &
+      "M  END", &
+      ">  <total energy / Eh>", &
+      "-18.421705869411", &
+      "", &
+      ">  <gradient norm / Eh/a0>", &
+      "0.000695317397", &
+      "", &
+      "$$$$"
+   rewind(unit)
+
+   call read_sdf(struc, unit, error)
+
+end subroutine test_invalid4_sdf
 
 
 end module test_read_ctfile

--- a/test/test_read_gaussian.f90
+++ b/test/test_read_gaussian.f90
@@ -32,7 +32,11 @@ subroutine collect_read_gaussian(testsuite)
    type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
    testsuite = [ &
-      & new_unittest("valid1-ein", test_valid1_ein) &
+      & new_unittest("valid1-ein", test_valid1_ein), &
+      & new_unittest("invalid1-ein", test_invalid1_ein, should_fail=.true.), &
+      & new_unittest("invalid2-ein", test_invalid2_ein, should_fail=.true.), &
+      & new_unittest("invalid3-ein", test_invalid3_ein, should_fail=.true.), &
+      & new_unittest("invalid4-ein", test_invalid4_ein, should_fail=.true.) &
       & ]
 
 end subroutine collect_read_gaussian
@@ -69,6 +73,114 @@ subroutine test_valid1_ein(error)
    if (allocated(error)) return
 
 end subroutine test_valid1_ein
+
+
+subroutine test_invalid1_ein(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "         4         1      zero       one", &
+      "         7      0.000000000000      0.000000000000     -0.114091591161      0.000000000000 ", &
+      "         1     -1.817280998039      0.000000000000      0.528409372569      0.000000000000 ", &
+      "         1      0.908640499019     -1.573811509290      0.528409372569      0.000000000000 ", &
+      "         1      0.908640499019      1.573811509290      0.528409372569      0.000000000000 ", &
+      " 1 2 1.000 3 1.000 4 1.000", &
+      " 2 1 1.000", &
+      " 3 1 1.000", &
+      " 4 1 1.000"
+   rewind(unit)
+
+   call read_gaussian_external(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid1_ein
+
+
+subroutine test_invalid2_ein(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "        -4         1         0         1", &
+      "         7      0.000000000000      0.000000000000     -0.114091591161      0.000000000000 ", &
+      "         1     -1.817280998039      0.000000000000      0.528409372569      0.000000000000 ", &
+      "         1      0.908640499019     -1.573811509290      0.528409372569      0.000000000000 ", &
+      "         1      0.908640499019      1.573811509290      0.528409372569      0.000000000000 ", &
+      " 1 2 1.000 3 1.000 4 1.000", &
+      " 2 1 1.000", &
+      " 3 1 1.000", &
+      " 4 1 1.000"
+   rewind(unit)
+
+   call read_gaussian_external(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid2_ein
+
+
+subroutine test_invalid3_ein(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "         4         1         0         1", &
+      "         7      0.000000000000      0.000000000000     -0.114091591161      0.000000000000 ", &
+      "         1     -1.817280998039      0.000000000000      0.528409372569      0.000000000000 ", &
+      "         1      0.908640499019     -1.573811509290      0.528409372569      0.000000000000 ", &
+      "         1      abcd.efgh-jklm      1.573811509290      0.528409372569      0.000000000000 ", &
+      " 1 2 1.000 3 1.000 4 1.000", &
+      " 2 1 1.000", &
+      " 3 1 1.000", &
+      " 4 1 1.000"
+   rewind(unit)
+
+   call read_gaussian_external(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid3_ein
+
+
+subroutine test_invalid4_ein(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "         4         1         0         1", &
+      "         7      0.000000000000      0.000000000000     -0.114091591161      0.000000000000 ", &
+      "         1     -1.817280998039      0.000000000000      0.528409372569      0.000000000000 ", &
+      "         1      0.908640499019     -1.573811509290      0.528409372569      0.000000000000 ", &
+      "        -1      0.908640499019      1.573811509290      0.528409372569      0.000000000000 ", &
+      " 1 2 1.000 3 1.000 4 1.000", &
+      " 2 1 1.000", &
+      " 3 1 1.000", &
+      " 4 1 1.000"
+   rewind(unit)
+
+   call read_gaussian_external(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid4_ein
 
 
 end module test_read_gaussian

--- a/test/test_read_pdb.f90
+++ b/test/test_read_pdb.f90
@@ -36,7 +36,10 @@ subroutine collect_read_pdb(testsuite)
       & new_unittest("valid1-pdb", test_valid1_pdb), &
       & new_unittest("valid2-pdb", test_valid2_pdb), &
       & new_unittest("valid3-pdb", test_valid3_pdb), &
-      & new_unittest("valid4-pdb", test_valid4_pdb) &
+      & new_unittest("valid4-pdb", test_valid4_pdb), &
+      & new_unittest("invalid1-pdb", test_invalid1_pdb, should_fail=.true.), &
+      & new_unittest("invalid2-pdb", test_invalid2_pdb, should_fail=.true.), &
+      & new_unittest("invalid3-pdb", test_invalid3_pdb, should_fail=.true.) &
       & ]
 
 end subroutine collect_read_pdb
@@ -329,6 +332,229 @@ subroutine test_valid4_pdb(error)
    if (allocated(error)) return
 
 end subroutine test_valid4_pdb
+
+
+subroutine test_invalid1_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM      1  N   GLY Z   1      -0.821  -2.072  16.609  1.00  9.93           N1+", &
+      "ATOM      2  CA  GLY Z   1      -1.705  -2.345  15.487  1.00  7.38           C", &
+      "ATOM      3  C   GLY Z   1      -0.968  -3.008  14.344  1.00  4.89           C", &
+      "ATOM      4  O   GLY Z   1       0.258  -2.982  14.292  1.00  5.05           O", &
+      "ATOM      5  HA2 GLY Z   1      -2.130  -1.405  15.135  1.00  0.00           H", &
+      "ATOM      6  HA3 GLY Z   1      -2.511  -2.999  15.819  1.00  0.00           H", &
+      "ATOM      7  H1  GLY Z   1      -1.364  -1.742  17.394  1.00  0.00           H", &
+      "ATOM      8  H2  GLY Z   1      -0.150  -1.365  16.344  1.00  0.00           H", &
+      "ATOM      9  H3  GLY Z   1      -0.334  -2.918  16.868  1.00  0.00           H", &
+      "ATOM     10  N   ASN Z   2      -1.721  -3.603  13.425  1.00  3.53           N", &
+      "ATOM     11  CA  ASN Z   2      -1.141  -4.323  12.291  1.00  1.85           C", &
+      "ATOM     12  C   ASN Z   2      -1.748  -3.900  10.968  1.00  3.00           C", &
+      "ATOM     13  O   ASN Z   2      -2.955  -3.683  10.873  1.00  3.99           O", &
+      "ATOM     14  CB  ASN Z   2      -1.353  -5.827  12.446  1.00  5.03           C", &
+      "ATOM     15  CG  ASN Z   2      -0.679  -6.391  13.683  1.00  5.08           C", &
+      "ATOM     16  OD1 ASN Z   2       0.519  -6.202  13.896  1.00  6.10           O", &
+      "ATOM     17  ND2 ASN Z   2      -1.448  -7.087  14.506  1.00  8.41           N", &
+      "ATOM     18  H   ASN Z   2      -2.726  -3.557  13.512  1.00  0.00           H", &
+      "ATOM     19  HA  ASN Z   2      -0.070  -4.123  12.263  1.00  0.00           H", &
+      "ATOM     20  HB2 ASN Z   2      -0.945  -6.328  11.568  1.00  0.00           H", &
+      "ATOM     21  HB3 ASN Z   2       a.bcd  -6.029  12.503  1.00  0.00           H", &
+      "ATOM     22 HD21 ASN Z   2      -2.427  -7.218  14.293  1.00  0.00           H", &
+      "ATOM     23 HD22 ASN Z   2      -1.056  -7.487  15.346  1.00  0.00           H", &
+      "ATOM     24  N   LEU Z   3      -0.907  -3.803   9.944  1.00  3.47           N", &
+      "ATOM     25  CA  LEU Z   3      -1.388  -3.576   8.586  1.00  3.48           C", &
+      "ATOM     26  C   LEU Z   3      -0.783  -4.660   7.709  1.00  3.29           C", &
+      "ATOM     27  O   LEU Z   3       0.437  -4.788   7.643  1.00  3.80           O", &
+      "ATOM     28  CB  LEU Z   3      -0.977  -2.185   8.081  1.00  3.88           C", &
+      "ATOM     29  CG  LEU Z   3      -1.524  -1.669   6.736  1.00  8.66           C", &
+      "ATOM     30  CD1 LEU Z   3      -1.225  -0.191   6.570  1.00  9.89           C", &
+      "ATOM     31  CD2 LEU Z   3      -0.962  -2.409   5.541  1.00 13.56           C", &
+      "ATOM     32  H   LEU Z   3       0.086  -3.888  10.109  1.00  0.00           H", &
+      "ATOM     33  HA  LEU Z   3      -2.475  -3.661   8.568  1.00  0.00           H", &
+      "ATOM     34  HB2 LEU Z   3      -1.284  -1.469   8.843  1.00  0.00           H", &
+      "ATOM     35  HB3 LEU Z   3       0.111  -2.162   8.026  1.00  0.00           H", &
+      "ATOM     36  HG  LEU Z   3      -2.606  -1.798   6.737  1.00  0.00           H", &
+      "ATOM     37 HD11 LEU Z   3      -1.623   0.359   7.423  1.00  0.00           H", &
+      "ATOM     38 HD12 LEU Z   3      -1.691   0.173   5.654  1.00  0.00           H", &
+      "ATOM     39 HD13 LEU Z   3      -0.147  -0.043   6.513  1.00  0.00           H", &
+      "ATOM     40 HD21 LEU Z   3      -1.168  -3.475   5.643  1.00  0.00           H", &
+      "ATOM     41 HD22 LEU Z   3      -1.429  -2.035   4.630  1.00  0.00           H", &
+      "ATOM     42 HD23 LEU Z   3       0.115  -2.250   5.489  1.00  0.00           H", &
+      "ATOM     43  N   VAL Z   4      -1.635  -5.424   7.029  1.00  3.17           N", &
+      "ATOM     44  CA  VAL Z   4      -1.165  -6.460   6.119  1.00  3.61           C", &
+      "ATOM     45  C   VAL Z   4      -1.791  -6.230   4.755  1.00  5.31           C", &
+      "ATOM     46  O   VAL Z   4      -3.014  -6.209   4.620  1.00  7.31           O", &
+      "ATOM     47  CB  VAL Z   4      -1.567  -7.872   6.593  1.00  5.31           C", &
+      "ATOM     48  CG1 VAL Z   4      -1.012  -8.934   5.633  1.00  6.73           C", &
+      "ATOM     49  CG2 VAL Z   4      -1.083  -8.120   8.018  1.00  5.48           C", &
+      "ATOM     50  H   VAL Z   4      -2.628  -5.282   7.146  1.00  0.00           H", &
+      "ATOM     51  HA  VAL Z   4      -0.080  -6.402   6.034  1.00  0.00           H", &
+      "ATOM     52  HB  VAL Z   4      -2.655  -7.939   6.585  1.00  0.00           H", &
+      "ATOM     53 HG11 VAL Z   4      -1.303  -9.926   5.980  1.00  0.00           H", &
+      "ATOM     54 HG12 VAL Z   4      -1.414  -8.766   4.634  1.00  0.00           H", &
+      "ATOM     55 HG13 VAL Z   4       0.075  -8.864   5.603  1.00  0.00           H", &
+      "ATOM     56 HG21 VAL Z   4      -1.377  -9.121   8.333  1.00  0.00           H", &
+      "ATOM     57 HG22 VAL Z   4       0.003  -8.032   8.053  1.00  0.00           H", &
+      "ATOM     58 HG23 VAL Z   4      -1.529  -7.383   8.686  1.00  0.00           H", &
+      "ATOM     59  N   SER Z   5      -0.966  -6.052   3.736  1.00  7.53           N", &
+      "ATOM     60  CA  SER Z   5      -1.526  -5.888   2.407  1.00 11.48           C", &
+      "ATOM     61  C   SER Z   5      -1.207  -7.085   1.529  1.00 16.35           C", &
+      "ATOM     62  O   SER Z   5      -0.437  -7.976   1.902  1.00 14.00           O", &
+      "ATOM     63  CB  SER Z   5      -1.031  -4.596   1.767  1.00 13.36           C", &
+      "ATOM     64  OG  SER Z   5       0.361  -4.652   1.540  1.00 15.80           O", &
+      "ATOM     65  OXT SER Z   5      -1.737  -7.178   0.429  1.00 17.09           O1-", &
+      "ATOM     66  H   SER Z   5       0.033  -6.031   3.880  1.00  0.00           H", &
+      "ATOM     67  HA  SER Z   5      -2.610  -5.822   2.504  1.00  0.00           H", &
+      "ATOM     68  HB2 SER Z   5      -1.543  -4.449   0.816  1.00  0.00           H", &
+      "ATOM     69  HB3 SER Z   5      -1.254  -3.759   2.428  1.00  0.00           H", &
+      "ATOM     70  HG  SER Z   5       0.653  -3.831   1.137  1.00  0.00           H", &
+      "TER      71      SER Z   5", &
+      "HETATM   72  O   HOH Z 101       0.935  -5.175  16.502  1.00 18.83           O", &
+      "HETATM   73  H1  HOH Z 101       0.794  -5.522  15.621  1.00  0.00           H", &
+      "HETATM   74  H2  HOH Z 101       1.669  -4.561  16.489  1.00  0.00           H", &
+      "HETATM   75  O   HOH Z 102       0.691  -8.408  17.879  0.91 56.55           O", &
+      "HETATM   76  H1  HOH Z 102       1.392  -8.125  18.466  0.91  0.00           H", &
+      "HETATM   77  H2  HOH Z 102       0.993  -8.356  16.972  0.91  0.00           H", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid1_pdb
+
+
+subroutine test_invalid2_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "HETATM 2463  CHA HEM A 154       9.596 -13.100  10.368  1.00  0.00           C", &
+      "HETATM 2464  CHB HEM A 154      11.541 -10.200   7.336  1.00  0.00           C", &
+      "HETATM 2465  CHC HEM A 154       9.504  -6.500   9.390  1.00  0.00           C", &
+      "HETATM 2466  CHD HEM A 154       7.260  -9.300  12.422  1.00  0.00           C", &
+      "HETATM 2467  C1A HEM A 154      10.383 -12.600   9.488  1.00  0.00           C", &
+      "HETATM 2468  C2A HEM A 154      10.970 -13.500   8.607  1.00  0.00           C", &
+      "HETATM 2469  C3A HEM A 154      11.537 -12.600   7.825  1.00  0.00           C", &
+      "HETATM 2470  C4A HEM A 154      11.295 -11.300   8.020  1.00  0.00           C", &
+      "HETATM 2471  CMA HEM A 154      12.628 -13.100   6.455  1.00  0.00           C", &
+      "HETATM 2472  CAA HEM A 154      11.250 -15.000   8.705  1.00  0.00           C", &
+      "HETATM 2473  CBA HEM A 154       9.870 -15.600   8.607  1.00  0.00           C", &
+      "HETATM 2474  CGA HEM A 154       8.899 -14.700   7.531  1.00  0.00           C", &
+      "HETATM 2475  O1A HEM A 154       8.337 -14.400   7.825  1.00  0.00           O", &
+      "HETATM 2476  O2A HEM A 154       9.062 -14.700   7.238  1.00  0.00           O", &
+      "HETATM 2477  C1B HEM A 154      11.178  -8.900   7.629  1.00  0.00           C", &
+      "HETATM 2478  C2B HEM A 154      11.745  -7.800   6.847  1.00  0.00           C", &
+      "HETATM 2479  C3B HEM A 154      11.020  -6.800   7.434  1.00  0.00           C", &
+      "HETATM 2480  C4B HEM A 154      10.370  -7.200   8.607  1.00  0.00           C", &
+      "HETATM 2481  CMB HEM A 154      12.615  -7.800   5.575  1.00  0.00           C", &
+      "HETATM 2482  CAB HEM A 154      11.203  -5.300   7.042  1.00  0.00           C", &
+      "HETATM 2483  CBB HEM A 154      11.911  -4.800   6.064  1.00  0.00           C", &
+      "HETATM 2484  C1C HEM A 154       8.817  -6.900  10.270  1.00  0.00           C", &
+      "HETATM 2485  C2C HEM A 154       8.130  -6.100  11.150  1.00  0.00           C", &
+      "HETATM 2486  C3C HEM A 154       7.543  -6.900  12.031  1.00  0.00           C", &
+      "HETATM 2487  C4C HEM A 154       7.805  -8.200  11.737  1.00  0.00           C", &
+      "HETATM 2488  CMC HEM A 154       8.051  -4.600  11.053  1.00  0.00           C", &
+      "HETATM 2489  CAC HEM A 154       6.414  -6.500  13.107  1.00  0.00           C", &
+      "HETATM 2490  CBC HEM A 154       6.193  -5.100  13.204  1.00  0.00           C", &
+      "HETATM 2491  C1D HEM A 154       7.843 -10.600  12.031  1.00  0.00           C", &
+      "HETATM 2492  C2D HEM A 154       7.256 -11.700  12.911  1.00  0.00           C", &
+      "HETATM 2493  C3D HEM A 154       8.101 -12.800  12.226  1.00  0.00           C", &
+      "HETATM 2494  C4D HEM A 154       8.809 -12.300  11.248  1.00  0.00           C", &
+      "HETATM 2495  CMD HEM A 154       6.427 -11.800  13.987  1.00  0.00           C", &
+      "HETATM 2496  CAD HEM A 154       7.897 -14.200  12.715  1.00  0.00           C", &
+      "HETATM 2497  CBD HEM A 154       8.085 -14.200  14.182  1.00  0.00           C", &
+      "HETATM 2498  CGD HEM A 154       9.023 -15.500  14.476  1.00  0.00           C", &
+      "HETATM 2499  O1D HEM A 154       8.898 -15.800  15.063  1.00  0.00           O", &
+      "HETATM 2500  O2D HEM A 154       9.527 -15.600  13.987  1.00  0.00           O", &
+      "HETATM 2501  NA  HEM A 154      10.487 -11.300   8.999  1.00  0.00           N", &
+      "HETATM 2502  NB  HEM A 154      10.570  -8.600   8.607  1.00  0.00           N", &
+      "HETATM 2503  NC  HEM A 154       8.613  -8.200  10.759  1.00  0.00           N", &
+      "HETATM 2504  ND  HEM A 154       8.709 -10.900  11.248  1.00  0.00           N", &
+      "HETATM 2505 FE   HEM A 154       9.621  -9.800   9.781  1.00  0.00 Fe", &
+      "HETATM 2506  HHA HEM A 154       9.526 -14.175  10.446  1.00  0.00           H", &
+      "HETATM 2507  HHB HEM A 154      12.102 -10.334   6.423  1.00  0.00           H", &
+      "HETATM 2508  HHC HEM A 154       9.433  -5.442   9.183  1.00  0.00           H", &
+      "HETATM 2509  HHD HEM A 154       6.484  -9.203  13.167  1.00  0.00           H", &
+      "HETATM 2510 HAA2 HEM A 154      11.721 -15.251   9.655  1.00  0.00           H", &
+      "HETATM 2511 HAA3 HEM A 154      11.871 -15.329   7.871  1.00  0.00           H", &
+      "HETATM 2512 HBA2 HEM A 154       9.950 -16.625   8.245  1.00  0.00           H", &
+      "HETATM 2513 HBA3 HEM A 154       9.407 -15.602   9.594  1.00  0.00           H", &
+      "HETATM 2514  HAB HEM A 154      10.678  -4.585   7.657  1.00  0.00           H", &
+      "HETATM 2515 HAC2 HEM A 154       5.478  -6.978  12.818  1.00  0.00           H", &
+      "HETATM 2516 HAC3 HEM A 154       6.713  -6.877  14.085  1.00  0.00           H", &
+      "HETATM 2517 HAD2 HEM A 154       6.889 -14.534  12.471  1.00  0.00           H", &
+      "HETATM 2518 HAD3 HEM A 154       8.627 -14.862  12.250  1.00  0.00           H", &
+      "HETATM 2519 HBD2 HEM A 154       8.582 -13.286  14.506  1.00  0.00           H", &
+      "HETATM 2520 HBD3 HEM A 154       7.124 -14.306  14.686  1.00  0.00           H", &
+      "HETATM 2521 HBB1 HEM A 154      12.463  -5.456   5.407  1.00  0.00           H", &
+      "HETATM 2522 HBB2 HEM A 154      11.944  -3.731   5.913  1.00  0.00           H", &
+      "HETATM 2523 HMD1 HEM A 154       5.952 -10.917  14.388  1.00  0.00           H", &
+      "HETATM 2524 HMD2 HEM A 154       6.244 -12.763  14.439  1.00  0.00           H", &
+      "HETATM 2525 HMA1 HEM A 154      12.066 -13.093   5.521  1.00  0.00           H", &
+      "HETATM 2526 HMA2 HEM A 154      13.462 -12.402   6.382  1.00  0.00           H", &
+      "HETATM 2527 HMA3 HEM A 154      13.009 -14.104   6.642  1.00  0.00           H", &
+      "HETATM 2528 HMB1 HEM A 154      13.413  -7.065   5.680  1.00  0.00           H", &
+      "HETATM 2529 HMB2 HEM A 154      11.998  -7.545   4.713  1.00  0.00           H", &
+      "HETATM 2530 HMB3 HEM A 154      13.048  -8.790   5.431  1.00  0.00           H", &
+      "HETATM 2531 HMC1 HEM A 154       8.716  -4.251  10.263  1.00  0.00           H", &
+      "HETATM 2532 HMC2 HEM A 154       8.353  -4.158  12.003  1.00  0.00           H", &
+      "HETATM 2533 HMC3 HEM A 154       7.027  -4.304  10.824  1.00  0.00           H", &
+      "HETATM 2534 HBC1 HEM A 154       5.472  -4.900  13.996  1.00  0.00           H", &
+      "HETATM 2535 HBC2 HEM A 154       5.804  -4.727  12.256  1.00  0.00           H", &
+      "HETATM 2536 HBC3 HEM A 154       7.133  -4.599  13.434  1.00  0.00           H", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid2_pdb
+
+
+subroutine test_invalid3_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM      1  N   GLY Z   1      -0.821  -2.072  16.609  1.00  9.93           N1+", &
+      "ANISOU    1  N   GLY Z   1     1184   1952    638    314   -191   -326       N", &
+      "ATOM      2  CA  GLY Z   1      -1.705  -2.345  15.487  1.00  7.38           C", &
+      "ANISOU    2  CA  GLY Z   1      957   1374    472    279   -124   -261       C", &
+      "ATOM      3  C   GLY Z   1      -0.968  -3.008  14.344  1.00  4.89           C", &
+      "ANISOU    3  C   GLY Z   1      899    614    343    211    112   -106       C", &
+      "ATOM      4  O   GLY Z   1       0.258  -2.982  14.292  1.00  5.05           O", &
+      "ANISOU    4  O   GLY Z   1      839    595    485    -11     -7   -180       O", &
+      "ATOM      5  HA2 GLY Z   1      -2.130  -1.405  15.135  1.00  0.00           H", &
+      "ATOM      6  HA3 GLY Z   1      -2.511  -2.999  15.819  1.00  0.00           H", &
+      "ATOM      7  H1  GLY Z   1      -1.364  -1.742  17.394  1.00  0.00           H", &
+      "ATOM      8  H2  GLY Z   1      -0.150  -1.365  16.344  1.00  0.00           H", &
+      "ATOM      9  H3  GLY Z   1      -0.334  -2.918  16.868  1.00  0.00           H", &
+      "ATOM     10  X   GLY Z   1      -1.141  -4.323  12.291  1.00  1.85           X", &
+      "TER      11      GLY Z   1", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid3_pdb
 
 
 end module test_read_pdb

--- a/test/test_read_turbomole.f90
+++ b/test/test_read_turbomole.f90
@@ -48,7 +48,16 @@ subroutine collect_read_turbomole(testsuite)
       & new_unittest("invalid4-coord", test_invalid4_coord, should_fail=.true.), &
       & new_unittest("invalid5-coord", test_invalid5_coord, should_fail=.true.), &
       & new_unittest("invalid6-coord", test_invalid6_coord, should_fail=.true.), &
-      & new_unittest("invalid7-coord", test_invalid7_coord, should_fail=.true.) &
+      & new_unittest("invalid7-coord", test_invalid7_coord, should_fail=.true.), &
+      & new_unittest("invalid8-coord", test_invalid8_coord, should_fail=.true.), &
+      & new_unittest("invalid9-coord", test_invalid9_coord, should_fail=.true.), &
+      & new_unittest("invalid10-coord", test_invalid10_coord, should_fail=.true.), &
+      & new_unittest("invalid11-coord", test_invalid11_coord, should_fail=.true.), &
+      & new_unittest("invalid12-coord", test_invalid12_coord, should_fail=.true.), &
+      & new_unittest("invalid13-coord", test_invalid13_coord, should_fail=.true.), &
+      & new_unittest("invalid14-coord", test_invalid14_coord, should_fail=.true.), &
+      & new_unittest("invalid15-coord", test_invalid15_coord, should_fail=.true.), &
+      & new_unittest("invalid16-coord", test_invalid16_coord, should_fail=.true.) &
       & ]
 
 end subroutine collect_read_turbomole
@@ -508,7 +517,7 @@ subroutine test_invalid4_coord(error)
    open(status='scratch', newunit=unit)
    write(unit, '(a)') &
       "$coord angs", &
-      "-1.1469443  0.0697649  1.1470196 ***", &
+      "-1.1469443  0.0697649  1.1470196 --->o", &
       "-1.2798308 -0.5232169  1.8902833 H", &
       "-1.0641398 -0.4956693  0.3569250 H", &
       "$end"
@@ -631,6 +640,285 @@ subroutine test_invalid7_coord(error)
    if (allocated(error)) return
 
 end subroutine test_invalid7_coord
+
+
+subroutine test_invalid8_coord(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "$coord angs", &
+      " 1.1847029  1.1150792 -0.0344641 O", &
+      " 0.4939088  0.9563767  0.6340089 H", &
+      " 2.0242676  1.0811246  0.4301417 H", &
+      "-1.1469443  abcd.efgh  1.1470196 O", &
+      "-1.2798308 -0.5232169  1.8902833 H", &
+      "-1.0641398 -0.4956693  0.3569250 H", &
+      "-0.1633508 -1.0289346 -1.2401808 O", &
+      " 0.4914771 -0.3248733 -1.0784838 H", &
+      "-0.5400907 -0.8496512 -2.1052499 H", &
+      "$end"
+   rewind(unit)
+
+   call read_coord(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+end subroutine test_invalid8_coord
+
+
+subroutine test_invalid9_coord(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "$cell", &
+      "  4.766080896955 4.766080896955 4.766080896955 60. 60. 60.", &
+      "$coord", &
+      "    0.00000000000000      0.00000000000000      0.00000000000000      c", &
+      "    2.38304045219106      1.39084904447079      0.97287218605834      c", &
+      "$periodic 4", &
+      "$end"
+   rewind(unit)
+
+   call read_coord(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid9_coord
+
+
+subroutine test_invalid10_coord(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "$coord", &
+      "    4.82824919102333E-02    5.71831000079710E-02    1.73514614763116E-01      C", &
+      "    4.82824919102333E-02    5.71831000079710E-02    2.78568246476372E+00      N", &
+      "    2.46093310136750E+00    5.71831000079710E-02    3.59954953387915E+00      C", &
+      "    3.99138416000780E+00   -2.21116805417472E-01    1.58364683739854E+00      N", &
+      "    2.54075511539052E+00   -1.18599185608072E-01   -5.86344093538442E-01      C", &
+      "   -2.06104824371096E+00    8.28021114689117E-01    4.40357113204146E+00      C", &
+      "    6.72173545596011E+00    2.10496546922931E-01    1.72565972456309E+00      C", &
+      "    3.05878562448454E+00    7.09403031823937E-02    5.55721088395376E+00      H", &
+      "    3.36822820962351E+00   -2.07680855613880E-01   -2.46191575873710E+00      H", &
+      "   -1.68465267663933E+00    1.48551338123814E-01   -9.21486948343917E-01      H", &
+      "   -3.83682349412373E+00    3.78984491295393E-01    3.43261116458953E+00      H", &
+      "   -1.96215889726624E+00   -2.17412943024358E-01    6.19219651728748E+00      H", &
+      "   -1.85966017471395E+00    2.87036107386343E+00    4.74746341688781E+00      H", &
+      "    7.49947096948557E+00   -8.77758695396645E-01    3.31081834253025E+00      H", &
+      "    7.58490546886959E+00   -4.29156708916399E-01   -4.73754235690626E-02      H", &
+      "    7.00829346274163E+00    2.24769645216395E+00    2.03795579552532E+00      H", &
+      "$eht charge=one unpaired=0", &
+      "$end"
+   rewind(unit)
+
+   call read_coord(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid10_coord
+
+
+subroutine test_invalid11_coord(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "$coord", &
+      "    4.82824919102333E-02    5.71831000079710E-02    1.73514614763116E-01      C", &
+      "    4.82824919102333E-02    5.71831000079710E-02    2.78568246476372E+00      N", &
+      "    2.46093310136750E+00    5.71831000079710E-02    3.59954953387915E+00      C", &
+      "    3.99138416000780E+00   -2.21116805417472E-01    1.58364683739854E+00      N", &
+      "    2.54075511539052E+00   -1.18599185608072E-01   -5.86344093538442E-01      C", &
+      "   -2.06104824371096E+00    8.28021114689117E-01    4.40357113204146E+00      C", &
+      "    6.72173545596011E+00    2.10496546922931E-01    1.72565972456309E+00      C", &
+      "    3.05878562448454E+00    7.09403031823937E-02    5.55721088395376E+00      H", &
+      "    3.36822820962351E+00   -2.07680855613880E-01   -2.46191575873710E+00      H", &
+      "   -1.68465267663933E+00    1.48551338123814E-01   -9.21486948343917E-01      H", &
+      "   -3.83682349412373E+00    3.78984491295393E-01    3.43261116458953E+00      H", &
+      "   -1.96215889726624E+00   -2.17412943024358E-01    6.19219651728748E+00      H", &
+      "   -1.85966017471395E+00    2.87036107386343E+00    4.74746341688781E+00      H", &
+      "    7.49947096948557E+00   -8.77758695396645E-01    3.31081834253025E+00      H", &
+      "    7.58490546886959E+00   -4.29156708916399E-01   -4.73754235690626E-02      H", &
+      "    7.00829346274163E+00    2.24769645216395E+00    2.03795579552532E+00      H", &
+      "$eht unpaired=", &
+      "$end"
+   rewind(unit)
+
+   call read_coord(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid11_coord
+
+
+subroutine test_invalid12_coord(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "$coord", &
+      "   -0.12918412100093      0.06210659750976     -2.13384498734326  c", &
+      "    0.12856915667443     -0.07403227791901      4.02358027265954  c", &
+      "$eht unpaired=0 charge=0", &
+      "$periodic 2", &
+      "$cell  angs", &
+      "    2.4809835980     2.4811430162   120.2612191150", &
+      "$coord", &
+      "   -0.12317720857511      2.75170732207802     -2.13345350602279  c", &
+      "    2.44816466162280      1.28612566399214      4.02317048854901  c", &
+      "$end"
+   rewind(unit)
+
+   call read_coord(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid12_coord
+
+
+subroutine test_invalid13_coord(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "$coord", &
+      "   -0.12918412100093      0.06210659750976     -2.13384498734326  c", &
+      "    0.12856915667443     -0.07403227791901      4.02358027265954  c", &
+      "   -0.12317720857511      2.75170732207802     -2.13345350602279  c", &
+      "    2.44816466162280      1.28612566399214      4.02317048854901  c", &
+      "$cell  angs", &
+      "    2.4809835980     2.4811430162   120.2612191150", &
+      "$eht unpaired=0 charge=0", &
+      "$periodic 2", &
+      "$cell  angs", &
+      "    2.4809835980     2.4811430162   120.2612191150", &
+      "$end"
+   rewind(unit)
+
+   call read_coord(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid13_coord
+
+
+subroutine test_invalid14_coord(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "$coord", &
+      "   -0.12918412100093      0.06210659750976     -2.13384498734326  c", &
+      "    0.12856915667443     -0.07403227791901      4.02358027265954  c", &
+      "   -0.12317720857511      2.75170732207802     -2.13345350602279  c", &
+      "    2.44816466162280      1.28612566399214      4.02317048854901  c", &
+      "$eht unpaired=0 charge=0", &
+      "$periodic 2", &
+      "$cell  angs", &
+      "    2.4809835980     2.4811430162   120.2612191150", &
+      "$periodic 2", &
+      "$end"
+   rewind(unit)
+
+   call read_coord(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid14_coord
+
+
+subroutine test_invalid15_coord(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "$eht charge=0", &
+      "$coord", &
+      "   -0.12918412100093      0.06210659750976     -2.13384498734326  c", &
+      "    0.12856915667443     -0.07403227791901      4.02358027265954  c", &
+      "   -0.12317720857511      2.75170732207802     -2.13345350602279  c", &
+      "    2.44816466162280      1.28612566399214      4.02317048854901  c", &
+      "$eht unpaired=0", &
+      "$periodic 2", &
+      "$cell  angs", &
+      "    2.4809835980     2.4811430162   120.2612191150", &
+      "$end"
+   rewind(unit)
+
+   call read_coord(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid15_coord
+
+
+subroutine test_invalid16_coord(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "$lattice angs", &
+      "       3.153833580475253       1.115048555743951       1.931320751454818", &
+      "       0.000000000000000       3.345145667231851       1.931320751454818", &
+      "       0.000000000000000       0.000000000000000       3.862641502909638", &
+      "$coord frac", &
+      "    0.25000000000000      0.25000000000000      0.25000000000000      f", &
+      "    0.75000000000000      0.75000000000000      0.75000000000000      f", &
+      "    0.00000000000000      0.00000000000000      0.00000000000000      ca", &
+      "$user-defined bonds", &
+      "$lattice angs", &
+      "       3.153833580475253       1.115048555743951       1.931320751454818", &
+      "       0.000000000000000       3.345145667231851       1.931320751454818", &
+      "       0.000000000000000       0.000000000000000       3.862641502909638", &
+      "$periodic 3", &
+      "$end"
+   rewind(unit)
+
+   call read_coord(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid16_coord
 
 
 end module test_read_turbomole


### PR DESCRIPTION
Much improved error messages for users to make input errors easier to spot

```
Error: Cannot read charges
  --> struc.mol:29:23-25
   |
29 | M  CHG  3   1   1   3   b   2  -1
   |                       ^^^ expected integer value
   |
```

```
Error: Cannot read eht entry
  --> struc.coord:18:13-15
   |
18 | $eht charge=one unpaired=0
   |             ^^^ expected integer value
   |
```

```
Error: Impossible number of atoms provided
 --> struc.xyz:1:1-2
  |
1 | -3
  | ^^ expected positive integer value
  |
```