### PR TITLE
Make parallelization of testsuite optional

### DIFF
--- a/src/mctc/env/testing.f90
+++ b/src/mctc/env/testing.f90
@@ -181,7 +181,7 @@ contains
 
 
 !> Driver for testsuite
-subroutine run_testsuite(collect, unit, stat)
+subroutine run_testsuite(collect, unit, stat, parallel)
 
    !> Collect tests
    procedure(collect_interface) :: collect
@@ -192,12 +192,19 @@ subroutine run_testsuite(collect, unit, stat)
    !> Number of failed tests
    integer, intent(inout) :: stat
 
+   !> Run tests in parallel
+   logical, intent(in), optional :: parallel
+
    type(unittest_type), allocatable :: testsuite(:)
+   logical :: parallelize
    integer :: ii
+
+   parallelize = .false.
+   if (present(parallel)) parallelize = parallel
 
    call collect(testsuite)
 
-   !$omp parallel do shared(testsuite, unit) reduction(+:stat)
+   !$omp parallel do shared(testsuite, unit) reduction(+:stat) if(parallelize)
    do ii = 1, size(testsuite)
       !$omp critical(mctc_env_testsuite)
       write(unit, '(1x, 3(1x, a), 1x, "(", i0, "/", i0, ")")') &


### PR DESCRIPTION
Not all tests are actually thread-safe, this enables to run the testsuite sequentially by default and on demand in parallel.

This is breaking the ABI, however since the tests are not part of the API usually exported in a shared library this is an acceptable ABI breakage and doesn't require to bump to 0.3.0 on the next release.