### PR TITLE
Implement support for helical boundary conditions in gen format

### DIFF
--- a/doc/format-gen.md
+++ b/doc/format-gen.md
@@ -98,9 +98,7 @@ No extension implemented to the original format.
 
 ## Missing Features
 
-The following features are currently not supported:
-
-- Helical boundary conditions
+The implementation of this format is (to our knowledge) feature-complete.
 
 @Note Feel free to contribute support for missing features
       or bring missing features to our attention by opening an issue.

--- a/src/mctc/io/utils.f90
+++ b/src/mctc/io/utils.f90
@@ -130,6 +130,11 @@ subroutine next_token(string, pos, token)
 
    integer :: start
 
+   if (pos >= len(string)) then
+      token = token_type(len(string)+1, len(string)+1)
+      return
+   end if
+
    do while(pos < len(string))
       pos = pos + 1
       select case(string(pos:pos))

--- a/src/mctc/io/write/aims.f90
+++ b/src/mctc/io/write/aims.f90
@@ -48,9 +48,12 @@ subroutine write_aims(self, unit)
    end if
 
    if (any(self%periodic)) then
-      do ilt = 1, size(self%lattice, 2)
-         write(unit, '(a, 1x, 3f24.14)') &
-            "lattice_vector", self%lattice(:, ilt) * autoaa
+      if (size(self%lattice, 2) /= 3) return
+      do ilt = 1, 3
+         if (self%periodic(ilt)) then
+            write(unit, '(a, 1x, 3f24.14)') &
+               "lattice_vector", self%lattice(:, ilt) * autoaa
+         end if
       end do
    end if
 

--- a/src/mctc/io/write/turbomole.f90
+++ b/src/mctc/io/write/turbomole.f90
@@ -27,19 +27,24 @@ contains
 subroutine write_coord(mol, unit)
    class(structure_type), intent(in) :: mol
    integer, intent(in) :: unit
-   integer :: iat
+   integer :: iat, ilt, npbc
 
    write(unit, '(a)') "$coord"
    do iat = 1, mol%nat
       write(unit, '(3es24.14, 6x, a)') mol%xyz(:, iat), trim(mol%sym(mol%id(iat)))
-   enddo
+   end do
    write(unit, '(a, *(1x, a, "=", i0))') &
       "$eht", "charge", nint(mol%charge), "unpaired", mol%uhf
    write(unit, '(a, 1x, i0)') "$periodic", count(mol%periodic)
    if (any(mol%periodic)) then
-      write(unit, '(a)') "$lattice bohr"
-      write(unit, '(3f20.14)') mol%lattice
-   endif
+      npbc = count(mol%periodic)
+      if (size(mol%lattice, 2) == 3) then
+         write(unit, '(a)') "$lattice bohr"
+         do ilt = 1, npbc
+            write(unit, '(3f20.14)') mol%lattice(:npbc, ilt)
+         end do
+      end if
+   end if
    write(unit, '(a)') "$end"
 
 end subroutine write_coord

--- a/src/mctc/io/write/vasp.f90
+++ b/src/mctc/io/write/vasp.f90
@@ -47,8 +47,8 @@ subroutine write_vasp(self, unit, comment_line)
          j = j+1
          izp = self%id(i)
          species(j) = self%id(i)
-      endif
-   enddo
+      end if
+   end do
 
    ! use vasp 5.x format
    if (present(comment_line)) then
@@ -65,22 +65,24 @@ subroutine write_vasp(self, unit, comment_line)
    write(unit, '(f20.14)') self%info%scale
    ! write the lattice parameters
    if (any(self%periodic)) then
-      do i = 1, size(self%lattice, 2)
-         write(unit, '(3f20.14)') self%lattice(:, i)*autoaa/self%info%scale
-      enddo
+      if (size(self%lattice, 2) == 3) then
+         write(unit, '(3f20.14)') self%lattice
+      else
+         write(unit, '(3f20.14)') spread(0.0_wp, 1, 9)
+      end if
    else
       write(unit, '(3f20.14)') spread(0.0_wp, 1, 9)
    end if
 
    do i = 1, j
       write(unit, '(1x, a)', advance='no') self%sym(species(i))
-   enddo
+   end do
    write(unit, '(a)')
 
    ! write the count of the consequtive atom types
    do i = 1, j
       write(unit, '(1x, i0)', advance='no') kinds(i)
-   enddo
+   end do
    write(unit, '(a)')
    deallocate(kinds, species)
 
@@ -93,7 +95,7 @@ subroutine write_vasp(self, unit, comment_line)
       ! now write the cartesian coordinates
       do i = 1, self%nat
          write(unit, '(3f20.14)') self%xyz(:, i)*autoaa/self%info%scale
-      enddo
+      end do
    else
       write(unit, '("Direct")')
       inv_lat = matinv_3x3(self%lattice)
@@ -102,8 +104,8 @@ subroutine write_vasp(self, unit, comment_line)
       ! now write the fractional coordinates
       do i = 1, self%nat
          write(unit, '(3f20.14)') abc(:, i)
-      enddo
-   endif
+      end do
+   end if
 
 end subroutine write_vasp
 

--- a/test/test_read_aims.f90
+++ b/test/test_read_aims.f90
@@ -13,6 +13,7 @@
 ! limitations under the License.
 
 module test_read_aims
+   use mctc_env, only : wp
    use mctc_env_testing, only : new_unittest, unittest_type, error_type, check
    use mctc_io_read_aims
    use mctc_io_structure
@@ -37,6 +38,8 @@ subroutine collect_read_aims(testsuite)
       & new_unittest("valid3-aims", test_valid3_aims), &
       & new_unittest("valid4-aims", test_valid4_aims), &
       & new_unittest("valid5-aims", test_valid5_aims), &
+      & new_unittest("valid6-aims", test_valid6_aims), &
+      & new_unittest("valid7-aims", test_valid7_aims), &
       & new_unittest("invalid1-aims", test_invalid1_aims, should_fail=.true.), &
       & new_unittest("invalid2-aims", test_invalid2_aims, should_fail=.true.), &
       & new_unittest("invalid3-aims", test_invalid3_aims, should_fail=.true.), &
@@ -248,6 +251,108 @@ subroutine test_valid5_aims(error)
    if (allocated(error)) return
 
 end subroutine test_valid5_aims
+
+
+subroutine test_valid6_aims(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc1, struc2
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "atom            0.00000000000000   0.00000000000000   0.00000000000000 Mg", &
+      "atom            1.48881365396205  -1.48881365396205   0.00000000000000 O", &
+      "atom            1.48881365396205   1.48881365396205   0.00000000000000 O", &
+      "atom            0.00000000000000   0.00000000000000   2.10550046127949 O", &
+      "atom            2.97762730792410   0.00000000000000   0.00000000000000 Mg", &
+      "atom            1.48881365396205  -1.48881365396205   2.10550046127949 Mg", &
+      "atom            1.48881365396205   1.48881365396205   2.10550046127949 Mg", &
+      "atom            2.97762730792410   0.00000000000000   2.10550046127949 O", &
+      "lattice_vector  2.97762730792410  -2.97762730792410   0.00000000000000", &
+      "lattice_vector  2.97762730792410   2.97762730792410   0.00000000000000"
+   rewind(unit)
+
+   call read_aims(struc1, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "atom_frac       0.00000000000000   0.00000000000000   0.00000000000000 Mg", &
+      "atom_frac       0.50000000000000   0.00000000000000   0.00000000000000 O", &
+      "atom_frac       0.00000000000000   0.50000000000000   0.00000000000000 O", &
+      "atom_frac       0.00000000000000   0.00000000000000   2.10550046127949 O", &
+      "atom_frac       0.50000000000000   0.50000000000000   0.00000000000000 Mg", &
+      "atom_frac       0.50000000000000   0.00000000000000   2.10550046127949 Mg", &
+      "atom_frac       0.00000000000000   0.50000000000000   2.10550046127949 Mg", &
+      "atom_frac       0.50000000000000   0.50000000000000   2.10550046127949 O", &
+      "lattice_vector  2.97762730792410  -2.97762730792410   0.00000000000000", &
+      "lattice_vector  2.97762730792410   2.97762730792410   0.00000000000000"
+   rewind(unit)
+
+   call read_aims(struc2, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, norm2(struc1%xyz - struc2%xyz), 0.0_wp, "Coordinates do not match")
+   if (allocated(error)) return
+
+end subroutine test_valid6_aims
+
+
+subroutine test_valid7_aims(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "atom             -1.05835465887935   1.85522662363901   0.00000000000000 B", &
+      "atom             -1.05835465887935   1.57910813351869   1.38575958673374 N", &
+      "atom             -1.05835465887935   0.79318285794365  -0.93200541748473 N", &
+      "atom             -1.05835465887935   2.94621239911295  -0.36993970607209 H", &
+      "atom             -1.05835465887935   0.24094589146163   1.83951376127452 B", &
+      "atom             -1.05835465887935  -0.54497939258025  -0.47825125458585 B", &
+      "atom             -1.05835465887935  -0.82109787740880   0.90750834908157 N", &
+      "atom             -1.05835465887935   0.01583015330186   2.96930500972370 H", &
+      "atom             -1.05835465887935  -1.41084943428660  -1.23810284035547 H", &
+      "atom             -1.05835465887935   2.39762594336943   2.10405675666812 H", &
+      "atom             -1.05835465887935  -1.85242037510793   1.25721697940438 H", &
+      "atom             -1.05835465887935   1.00598756166737  -2.00001121245014 H", &
+      "atom              1.05835465887935   0.82109787740880  -0.90750833320625 B", &
+      "atom              1.05835465887935   0.54497938728848   0.47825125193996 N", &
+      "atom              1.05835465887935  -0.24094588775739  -1.83951375598275 N", &
+      "atom              1.05835465887935   1.91208365288273  -1.27744804245341 H", &
+      "atom              1.05835465887935  -0.79318285794365   0.93200542277650 B", &
+      "atom              1.05835465887935  -1.57910813881047  -1.38575959202551 B", &
+      "atom              1.05835465887935  -1.85522662893078   0.00000001308910 N", &
+      "atom              1.05835465887935  -1.01829859700301   2.06179667651746 H", &
+      "atom              1.05835465887935  -2.44497818051681  -2.14561117356172 H", &
+      "atom              1.05835465887935   1.36349719184744   1.19654842346187 H", &
+      "atom              1.05835465887935  -2.88654912133814   0.34970864461060 H", &
+      "atom              1.05835465887935  -0.02814118763207  -2.90751955094817 H", &
+      "lattice_vector    4.23341864610095   0.00000000000000   0.00000000000000"
+   rewind(unit)
+
+   call read_aims(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 24, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 3, "Number of species does not match")
+   if (allocated(error)) return
+   call check(error, count(struc%periodic), 1, "Periodicity does not match")
+   if (allocated(error)) return
+
+end subroutine test_valid7_aims
+
 
 
 subroutine test_invalid1_aims(error)

--- a/test/test_read_genformat.f90
+++ b/test/test_read_genformat.f90
@@ -36,12 +36,17 @@ subroutine collect_read_genformat(testsuite)
       & new_unittest("valid2-gen", test_valid2_gen), &
       & new_unittest("valid3-gen", test_valid3_gen), &
       & new_unittest("valid4-gen", test_valid4_gen), &
+      & new_unittest("valid5-gen", test_valid5_gen), &
+      & new_unittest("valid6-gen", test_valid6_gen), &
       & new_unittest("invalid1-gen", test_invalid1_gen, should_fail=.true.), &
       & new_unittest("invalid2-gen", test_invalid2_gen, should_fail=.true.), &
       & new_unittest("invalid3-gen", test_invalid3_gen, should_fail=.true.), &
       & new_unittest("invalid4-gen", test_invalid4_gen, should_fail=.true.), &
       & new_unittest("invalid5-gen", test_invalid5_gen, should_fail=.true.), &
-      & new_unittest("invalid6-gen", test_invalid6_gen, should_fail=.true.) &
+      & new_unittest("invalid6-gen", test_invalid6_gen, should_fail=.true.), &
+      & new_unittest("invalid7-gen", test_invalid7_gen, should_fail=.true.), &
+      & new_unittest("invalid8-gen", test_invalid8_gen, should_fail=.true.), &
+      & new_unittest("invalid9-gen", test_invalid9_gen, should_fail=.true.) &
       & ]
 
 end subroutine collect_read_genformat
@@ -182,6 +187,88 @@ subroutine test_valid4_gen(error)
 end subroutine test_valid4_gen
 
 
+subroutine test_valid5_gen(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "   20  H", &
+      "  C", &
+      "    1 1    0.2756230044E+01    0.2849950460E+01    0.1794011798E+01", &
+      "    2 1    0.2656226397E+01    0.2949964389E+01    0.3569110265E+00", &
+      "    3 1    0.4149823216E+00    0.3947943175E+01    0.1774023191E+01", &
+      "    4 1   -0.1984731085E+01    0.3437783679E+01    0.1784008240E+01", &
+      "    5 1   -0.3626350732E+01    0.1614594006E+01    0.1784022394E+01", &
+      "    6 1   -0.3882893767E+01   -0.8252790149E+00    0.1784006601E+01", &
+      "    7 1   -0.2656230041E+01   -0.2949950471E+01    0.1784011798E+01", &
+      "    8 1   -0.4149823216E+00   -0.3947943175E+01    0.1784023191E+01", &
+      "    9 1    0.1984731085E+01   -0.3437783679E+01    0.1784008240E+01", &
+      "   10 1    0.3626350732E+01   -0.1614594006E+01    0.1784022394E+01", &
+      "   11 1    0.3882893767E+01    0.8252790258E+00    0.1784006601E+01", &
+      "   12 1    0.4149905833E+00    0.3947943870E+01    0.3569255177E+00", &
+      "   13 1   -0.1984725150E+01    0.3437762712E+01    0.3569151866E+00", &
+      "   14 1   -0.3626358050E+01    0.1614595957E+01    0.3569260541E+00", &
+      "   15 1   -0.3882900023E+01   -0.8252696970E+00    0.3569133218E+00", &
+      "   16 1   -0.2656226396E+01   -0.2949964400E+01    0.3569110265E+00", &
+      "   17 1   -0.4149905833E+00   -0.3947943870E+01    0.3569255177E+00", &
+      "   18 1    0.1984725150E+01   -0.3437762712E+01    0.3569151866E+00", &
+      "   19 1    0.3626358050E+01   -0.1614595957E+01    0.3569260541E+00", &
+      "   20 1    0.3882900026E+01    0.8252697074E+00    0.3569133218E+00", &
+      "    0 0 0", &
+      "    0.2140932670E+01   18.0 1"
+   rewind(unit)
+
+   call read_genformat(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, count(struc%periodic), 1, "Incorrect periodicity")
+   if (allocated(error)) return
+   call check(error, struc%nat, 20, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 1, "Number of species does not match")
+   if (allocated(error)) return
+
+end subroutine test_valid5_gen
+
+
+subroutine test_valid6_gen(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "    2  H", &
+      "  C", &
+      "    1 1    0.0 0.0 1.4271041431", &
+      "    2 1    0.0 0.0 0.0", &
+      "   -0.2703556133E+01  -0.2906666140E+01 -0.3618948259E+00", &
+      "    0.2140932670E+01   18.00000000 10"
+   rewind(unit)
+
+   call read_genformat(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, count(struc%periodic), 1, "Incorrect periodicity")
+   if (allocated(error)) return
+   call check(error, struc%nat, 2, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 1, "Number of species does not match")
+   if (allocated(error)) return
+
+end subroutine test_valid6_gen
+
+
 subroutine test_invalid1_gen(error)
 
    !> Error handling
@@ -204,7 +291,6 @@ subroutine test_invalid1_gen(error)
 
    call read_genformat(struc, unit, error)
    close(unit)
-   if (allocated(error)) return
 
 end subroutine test_invalid1_gen
 
@@ -231,7 +317,6 @@ subroutine test_invalid2_gen(error)
 
    call read_genformat(struc, unit, error)
    close(unit)
-   if (allocated(error)) return
 
 end subroutine test_invalid2_gen
 
@@ -258,7 +343,6 @@ subroutine test_invalid3_gen(error)
 
    call read_genformat(struc, unit, error)
    close(unit)
-   if (allocated(error)) return
 
 end subroutine test_invalid3_gen
 
@@ -279,7 +363,6 @@ subroutine test_invalid4_gen(error)
 
    call read_genformat(struc, unit, error)
    close(unit)
-   if (allocated(error)) return
 
 end subroutine test_invalid4_gen
 
@@ -302,7 +385,6 @@ subroutine test_invalid5_gen(error)
 
    call read_genformat(struc, unit, error)
    close(unit)
-   if (allocated(error)) return
 
 end subroutine test_invalid5_gen
 
@@ -329,9 +411,92 @@ subroutine test_invalid6_gen(error)
 
    call read_genformat(struc, unit, error)
    close(unit)
-   if (allocated(error)) return
 
 end subroutine test_invalid6_gen
+
+
+subroutine test_invalid7_gen(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "12 H", &
+      " C H ", &
+      " 1 1   1.39792890   0.00000000  -0.00000000", &
+      " 2 2   2.49455487  -0.00000000   0.00000000", &
+      " 3 1   0.69896445   1.21064194  -0.00000000", &
+      " 4 2   1.24727743   2.16034789   0.00000000", &
+      " 5 1  -0.69896445   1.21064194  -0.00000000", &
+      " 6 2  -1.24727743   2.16034789   0.00000000", &
+      " 7 1  -1.39792890  -0.00000000  -0.00000000", &
+      " 8 2  -2.49455487   0.00000000   0.00000000", &
+      " 9 1  -0.69896445  -1.21064194  -0.00000000", &
+      "10 2  -1.24727743  -2.16034789   0.00000000", &
+      "11 1   0.69896445  -1.21064194  -0.00000000", &
+      "12 2   1.24727743  -2.16034789   0.00000000", &
+      "  0 0 0", &
+      "  3.0 ***** 1"
+   rewind(unit)
+
+   call read_genformat(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid7_gen
+
+
+subroutine test_invalid8_gen(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "   2  H", &
+      "  C", &
+      "    1 1    0.2756230044E+01    0.2849950460E+01    0.1794011798E+01", &
+      "    2 1    0.2656226397E+01    0.2949964389E+01    0.3569110265E+00", &
+      "    0 0 0", &
+      "    0.2140932670E+01 18.0 -10"
+   rewind(unit)
+
+   call read_genformat(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid8_gen
+
+
+subroutine test_invalid9_gen(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "    2  S", &
+      "  C", &
+      "    1 1    0.0000000000E+00    0.0000000000E+00    0.0000000000E+00", &
+      "    2 1    1.5000000000E+00    0.0000000000E+00    0.0000000000E+00", &
+      "    0.0000000000E+00    0.0000000000E+00", &
+      "    0.2000000000E+01    0.0000000000E+00    0.0000000000E+00", &
+      "    0.0000000000E+00    0.1000000000E+03    0.0000000000E+00", &
+      "    0.0000000000E+00    0.0000000000E+00    0.1000000000E+03"
+   rewind(unit)
+
+   call read_genformat(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid9_gen
 
 
 end module test_read_genformat

--- a/test/test_read_turbomole.f90
+++ b/test/test_read_turbomole.f90
@@ -42,6 +42,8 @@ subroutine collect_read_turbomole(testsuite)
       & new_unittest("valid7-coord", test_valid7_coord), &
       & new_unittest("valid8-coord", test_valid8_coord), &
       & new_unittest("valid9-coord", test_valid9_coord), &
+      & new_unittest("valid10-coord", test_valid10_coord), &
+      & new_unittest("valid11-coord", test_valid11_coord), &
       & new_unittest("invalid1-coord", test_invalid1_coord, should_fail=.true.), &
       & new_unittest("invalid2-coord", test_invalid2_coord, should_fail=.true.), &
       & new_unittest("invalid3-coord", test_invalid3_coord, should_fail=.true.), &
@@ -420,6 +422,102 @@ subroutine test_valid9_coord(error)
    if (allocated(error)) return
 
 end subroutine test_valid9_coord
+
+
+subroutine test_valid10_coord(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "$cell", &
+      " 8.00000006 ", &
+      "$periodic 1", &
+      "$coord", &
+      "   -2.00000001000000      3.50586945000000      0.00000000000000      b", &
+      "   -2.00000001000000      2.98408124000000      2.61870552000000      n", &
+      "   -2.00000001000000      1.49889804000000     -1.76123460000000      n", &
+      "   -2.00000001000000      5.56753332000000     -0.69908457400000      h", &
+      "   -2.00000001000000      0.45532164600000      3.47617645000000      b", &
+      "   -2.00000001000000     -1.02986157000000     -0.90376369200000      b", &
+      "   -2.00000001000000     -1.55164977000000      1.71494186000000      n", &
+      "   -2.00000001000000      0.02991464770000      5.61117202000000      h", &
+      "   -2.00000001000000     -2.66611845000000     -2.33967477000000      h", &
+      "   -2.00000001000000      4.53085539000000      3.97609015000000      h", &
+      "   -2.00000001000000     -3.50056641000000      2.37579525000000      h", &
+      "   -2.00000001000000      1.90104056000000     -3.77947261000000      h", &
+      "    2.00000001000000      1.55164977000000     -1.71494183000000      b", &
+      "    2.00000001000000      1.02986156000000      0.90376368700000      n", &
+      "    2.00000001000000     -0.45532163900000     -3.47617644000000      n", &
+      "    2.00000001000000      3.61331364000000     -2.41402641000000      h", &
+      "    2.00000001000000     -1.49889804000000      1.76123461000000      b", &
+      "    2.00000001000000     -2.98408125000000     -2.61870553000000      b", &
+      "    2.00000001000000     -3.50586946000000      0.00000002473480      n", &
+      "    2.00000001000000     -1.92430504000000      3.89623019000000      h", &
+      "    2.00000001000000     -4.62033813000000     -4.05461660000000      h", &
+      "    2.00000001000000      2.57663570000000      2.26114832000000      h", &
+      "    2.00000001000000     -5.45478609000000      0.66085341700000      h", &
+      "    2.00000001000000     -0.05317912580000     -5.49441445000000      h", &
+      "$user-defined bonds", &
+      "$end"
+   rewind(unit)
+
+   call read_coord(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 24, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 3, "Number of species does not match")
+   if (allocated(error)) return
+   call check(error, count(struc%periodic), 1, "Periodic of system does not match")
+   if (allocated(error)) return
+
+end subroutine test_valid10_coord
+
+
+subroutine test_valid11_coord(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "$coord frac", &
+      "    0.00000000000000      0.00000000000000      0.00000000000000      mg", &
+      "    0.50000000000000      0.00000000000000      0.00000000000000      o", &
+      "    0.00000000000000      0.50000000000000      0.00000000000000      o", &
+      "    0.00000000000000      0.00000000000000      3.97881835572287      o", &
+      "    0.50000000000000      0.50000000000000      0.00000000000000      mg", &
+      "    0.50000000000000      0.00000000000000      3.97881835572287      mg", &
+      "    0.00000000000000      0.50000000000000      3.97881835572287      mg", &
+      "    0.50000000000000      0.50000000000000      3.97881835572287      o", &
+      "$periodic 2", &
+      "$lattice", &
+      " 5.626898880882 -5.626898880882", &
+      " 5.626898880882  5.626898880882", &
+      "$end"
+   rewind(unit)
+
+   call read_coord(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 8, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 2, "Number of species does not match")
+   if (allocated(error)) return
+   call check(error, count(struc%periodic), 2, "Periodic of system does not match")
+   if (allocated(error)) return
+
+end subroutine test_valid11_coord
 
 
 subroutine test_invalid1_coord(error)


### PR DESCRIPTION
@bhourahine I have a couple of questions regarding the format

- I'm storing the helical z-axis like in DFTB+ in the first lattice vector (`shape(lattice) ==  [3, 1]`), is this the best representation?
- formats not supporting helical boundary conditions will drop the helical axis on write (similar behavior as with lattice vectors in molecular formats)
- helical boundary conditions only round-trip in gen format at the moment
- Turbomole `coord` also supports 1D periodic boundary conditions, however the periodic dimension is always given along the x-axis (`shape(lattice) ==  [3, 3]`), probably requires rotation of the coordinate system to write this in gen format
- FHI-aims `geometry.in` can define 1D periodicity as well, have to check in detail how this is supposed to work for the `atom_frac` keywords, but same issues as with the Turbomole `coord` format

Currently tested error conditions for gen format:

```
  Starting invalid1-gen ... (7/15)
       ... invalid1-gen [EXPECTED FAIL]
  Message: Error: Could not read number of atoms
 --> (input):1:1-2
  |
1 | -2  F
  | ^^ expected integer value
  |
  Starting invalid2-gen ... (8/15)
       ... invalid2-gen [EXPECTED FAIL]
  Message: Error: Invalid input version found
 --> (input):1:4
  |
1 | 2  X
  |    ^ unknown identifier
  |
  Starting invalid3-gen ... (9/15)
       ... invalid3-gen [EXPECTED FAIL]
  Message: Error: Cannot map symbol to atomic number
 --> (input):2:4-7
  |
2 | Ga ***As
  |    ^^^^ unknown element
  |
  Starting invalid4-gen ... (10/15)
       ... invalid4-gen [EXPECTED FAIL]
  Message: Error: Cannot read coordinates
 --> (input):2
  |
2 | 
  |^ unexpected value
  |
  Starting invalid5-gen ... (11/15)
       ... invalid5-gen [EXPECTED FAIL]
  Message: Error: Unexpected end of file
 --> (input):4
  |
4 | 
  |^ missing lattice information
  |
  Starting invalid6-gen ... (12/15)
       ... invalid6-gen [EXPECTED FAIL]
  Message: Error: Cannot read lattice vector
 --> (input):6:1-13
  |
6 | ************* ************* 0.0000000E+00
  | ^^^^^^^^^^^^^ expected real value
  |
  Starting invalid7-gen ... (13/15)
       ... invalid7-gen [EXPECTED FAIL]
  Message: Error: Cannot read lattice vector
  --> (input):16:5-9
   |
16 | 3.0 ***** 1
   |     ^^^^^ expected real value
   |
  Starting invalid8-gen ... (14/15)
       ... invalid8-gen [EXPECTED FAIL]
  Message: Error: Invalid helical axis rotation order
 --> (input):6:23-25
  |
6 | 0.2140932670E+01 18.0 -10
  |                       ^^^ expected positive value
  |
  Starting invalid9-gen ... (15/15)
       ... invalid9-gen [EXPECTED FAIL]
  Message: Error: Cannot read origin
 --> (input):5:37
  |
5 | 0.0000000000E+00    0.0000000000E+00
  |                                     ^ expected real value
  |
```