### PR TITLE
Correctly update chain number when changing to another chain

### DIFF
--- a/src/mctc/io/write/pdb.f90
+++ b/src/mctc/io/write/pdb.f90
@@ -56,6 +56,7 @@ subroutine write_pdb(mol, unit, number)
          else if (mol%pdb(iat)%chains /= last_chain) then
             write(unit, '("TER   ",i5,6x,a3,1x,a1,i4)') iat + offset, &
                &  mol%pdb(iat-1)%residue, last_chain, mol%pdb(iat)%residue_number
+            last_chain = mol%pdb(iat)%chains
             offset = offset+1
          endif
 


### PR DESCRIPTION
Stale chain identifier would lead to repeated writing of `TER` after a chain changed.