### PR TITLE
Allow reading of dot-files from input file directory

### DIFF
--- a/man/mctc-convert.1.adoc
+++ b/man/mctc-convert.1.adoc
@@ -52,6 +52,9 @@ be read _before_ the input structure.
 *--template-format* _format_::
 Hint for the format of the template file (only used if template file name is provided)
 
+*--ignore-dot-files*::
+Do not read charge and spin from .CHRG and .UHF files
+
 *--version*::
 Print program version and exit
 


### PR DESCRIPTION
cc @hoelzerC

Allows reading `.CHRG` and `.UHF` from directory of input file (not the current working directory). 

New error message from command-line driver for invalid input.

- invalid value

```
Error: Cannot read value from file
 --> ./.CHRG:1:1-2
  |
1 | AB
  | ^^ expected integer value
  |
```

- no value

```
Error: Cannot read value from file
 --> ./.CHRG:1:1
  |
1 | 
  | ^ expected integer value
  |
```

New option to ignore `.CHRG` and `.UHF` with `--ignore-dot-files`.