### PR TITLE
Allow building with Intel-CL

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -27,6 +27,11 @@ elif fc_id == 'intel'
     '-traceback',
     language: 'fortran',
   )
+elif fc_id == 'intel-cl'
+  add_project_arguments(
+    '-fpp',
+    language: 'fortran',
+  )
 elif fc_id == 'pgi' or fc_id == 'nvidia_hpc'
   add_project_arguments(
     '-Mbackslash',

--- a/subprojects/packagefiles/json-fortran-8.2.5/meson.build
+++ b/subprojects/packagefiles/json-fortran-8.2.5/meson.build
@@ -4,6 +4,14 @@ project(
   version: files('.VERSION'),
 )
 
+fc = meson.get_compiler('fortran')
+if fc.get_id() == 'intel-cl'
+  add_project_arguments(
+    '-fpp',
+    language: 'fortran',
+  )
+endif
+
 jsonfortran_lib = library(
   meson.project_name(),
   sources: files(


### PR DESCRIPTION
Tested with Intel oneAPI 2022.1 and VS2022
```
cmake -B _build_intel -DCMAKE_INSTALL_PREFIX=%CD%\_dist
cmake --build _build_intel
ctest --test-dir _build_intel
cmake --build _build_intel --config Release
cmake --install _build intel
```

```
meson setup _build_intel --prefix=%CD%\_dist --default-library=static
meson compiler -C _build_intel
meson test -C _build_intel
meson install -C _build_intel
```