### PR TITLE
Remove compiler ID from include directrory

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -19,7 +19,7 @@ option(WITH_JSON "Enable support for JSON parsing via json-fortran" FALSE)
 
 set(
   "${PROJECT_NAME}-module-dir"
-  "${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}-${CMAKE_Fortran_COMPILER_VERSION}"
+  "${PROJECT_NAME}/modules"
   CACHE STRING
   "Subdirectory to install generated module files to"
 )

--- a/meson.build
+++ b/meson.build
@@ -69,7 +69,7 @@ if install
     install_dir: get_option('datadir')/'licenses'/meson.project_name()
   )
 
-  module_id = meson.project_name() / fc_id + '-' + fc.version()
+  module_id = meson.project_name() / 'modules'
   meson.add_install_script(
     find_program(files('config'/'install-mod.py')),
     get_option('includedir') / module_id,


### PR DESCRIPTION
It adds the compiler ID to the include directory: include/mctc-lib/GNU-11.3.0/

This is very unconventional and unnecessary.

With this patch it now installs headers into include/mctc-lib which
aligns with the way how most projects install their headers.