### PR TITLE
add copy assignment to structure_type

### DIFF
--- a/src/mctc/io/structure.f90
+++ b/src/mctc/io/structure.f90
@@ -75,6 +75,10 @@ module mctc_io_structure
       !> PDB atomic data annotations
       type(pdb_data), allocatable :: pdb(:)
 
+      contains
+      procedure :: copy_structure_type
+      generic,public :: assignment(=) => copy_structure_type
+
    end type structure_type
 
 
@@ -278,5 +282,37 @@ subroutine new_structure_sym(self, sym, xyz, charge, uhf, lattice, periodic, &
 
 end subroutine new_structure_sym
 
+subroutine copy_structure_type(self,from)
+   class(structure_type),intent(inout) :: self
+   class(structure_type),intent(in) :: from
+
+   self%nat = from%nat
+   self%nid = from%nid
+   self%nbd = from%nbd
+   self%charge = from%charge
+   self%uhf = from%uhf
+   
+   allocate(self%id(from%nat))
+   allocate(self%xyz(3, from%nat))
+   allocate(self%num(size(from%num)))
+   allocate(self%sym(size(from%sym)))
+   
+   self%id = from%id
+   self%xyz(:, :) = from%xyz(:, :)
+   self%num = from%num
+   self%sym = from%sym
+   
+   allocate(self%lattice(size(from%lattice)))
+   allocate(self%periodic(size(from%periodic)))
+   allocate(self%bond(size(from%bond)))
+
+   self%lattice = from%lattice
+   self%periodic = from%periodic
+   self%bond = from%bond
+   
+   self%comment = from%comment
+   self%info = from%info
+
+end subroutine copy_structure_type
 
 end module mctc_io_structure


### PR DESCRIPTION
Hey, 

I suggest this addition of a copy assignment as it resolves an issue I and probably also other people have when trying to compile the related dftd4 project with the newest intel oneAPI compiles (2023.0). Due to the implementation of the numeric hessian calculation in dftd4 in the file numdiff.f90, line 63 is not well defined and it seems that the new intel compilers can not cope with this resulting in a Segmentation Fault.

The explicit definition of the assignment of the "="  operator leads to a smooth compilation and the testsuite passes, for the C-API as well. 

Maybe the addition of pdb and sdf is also necessary.

Best regards
Pit