### PR TITLE
Allows writing of Turbomole format with angstrom.

### DIFF
--- a/test/test_write_turbomole.f90
+++ b/test/test_write_turbomole.f90
@@ -18,6 +18,7 @@ module test_write_turbomole
    use mctc_io_write_turbomole
    use mctc_io_read_turbomole
    use mctc_io_structure
+   use mctc_io_convert, only : autoaa
    implicit none
    private
 
@@ -35,7 +36,8 @@ subroutine collect_write_turbomole(testsuite)
 
    testsuite = [ &
       & new_unittest("valid1-coord", test_valid1_coord), &
-      & new_unittest("valid2-coord", test_valid2_coord) &
+      & new_unittest("valid2-coord", test_valid2_coord), &
+      & new_unittest("valid-angs", test_valid_coord_angs) &
       & ]
 
 end subroutine collect_write_turbomole
@@ -96,5 +98,36 @@ subroutine test_valid2_coord(error)
 
 end subroutine test_valid2_coord
 
+subroutine test_valid_coord_angs(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit, nat, nid
+
+   call get_structure(struc, "mindless01")
+   nat = struc%nat
+   nid = struc%nid
+
+   struc%xyz = struc%xyz * autoaa
+   struc%info%angs_coord = .true.
+
+   open(status='scratch', newunit=unit)
+   call write_coord(struc, unit)
+   rewind(unit)
+
+   call read_coord(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, nat, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, nid, "Number of species does not match")
+   if (allocated(error)) return
+   call check(error, struc%info%angs_coord, .true., "Coordinates are not written in angstrom.")
+   if (allocated(error)) return
+
+end subroutine test_valid_coord_angs
 
 end module test_write_turbomole

--- a/test/test_write_turbomole.f90
+++ b/test/test_write_turbomole.f90
@@ -37,7 +37,8 @@ subroutine collect_write_turbomole(testsuite)
    testsuite = [ &
       & new_unittest("valid1-coord", test_valid1_coord), &
       & new_unittest("valid2-coord", test_valid2_coord), &
-      & new_unittest("valid-angs", test_valid_coord_angs) &
+      & new_unittest("valid1-coord-angs", test_valid1_coord_angs), &
+      & new_unittest("valid2-coord-angs", test_valid2_coord_angs) &
       & ]
 
 end subroutine collect_write_turbomole
@@ -98,7 +99,7 @@ subroutine test_valid2_coord(error)
 
 end subroutine test_valid2_coord
 
-subroutine test_valid_coord_angs(error)
+subroutine test_valid1_coord_angs(error)
 
    !> Error handling
    type(error_type), allocatable, intent(out) :: error
@@ -128,6 +129,39 @@ subroutine test_valid_coord_angs(error)
    call check(error, struc%info%angs_coord, .true., "Coordinates are not written in angstrom.")
    if (allocated(error)) return
 
-end subroutine test_valid_coord_angs
+end subroutine test_valid1_coord_angs
+
+subroutine test_valid2_coord_angs(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit, nat, nid
+
+   call get_structure(struc, "x01")
+   nat = struc%nat
+   nid = struc%nid
+
+   struc%xyz = struc%xyz * autoaa
+   struc%lattice = struc%lattice * autoaa
+   struc%info%angs_coord = .true.
+
+   open(status='scratch', newunit=unit)
+   call write_coord(struc, unit)
+   rewind(unit)
+
+   call read_coord(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, nat, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, nid, "Number of species does not match")
+   if (allocated(error)) return
+   call check(error, struc%info%angs_coord, .true., "Coordinates are not written in angstrom.")
+   if (allocated(error)) return
+
+end subroutine test_valid2_coord_angs
 
 end module test_write_turbomole


### PR DESCRIPTION
At the moment, mctc-lib allows reading of coord files in angstrom format (``$coord angs``), but can not write these files. With this PR, mctc-lib will write ``$coord angs`` files if specified in the input.