### PR TITLE
build(cmake): fix compiler detection logic

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -39,9 +39,9 @@ install(
 
 # Compiler-specific configurations 
 if(
-  CMAKE_Fortran_COMPILER_ID MATCHES "PGI"
-  OR CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC"
-  OR CMAKE_Fortran_COMPILER_ID MATCHES "Flang"
+  "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "PGI"
+  OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "NVHPC"
+  OR "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Flang"
 )
   set(
     CMAKE_Fortran_FLAGS


### PR DESCRIPTION
the condition wrongly matched LLVMFlang (flang-new), which does not support `-Mbackslash` and `-Mallocatable=03`.

https://cmake.org/cmake/help/v3.24/variable/CMAKE_LANG_COMPILER_ID.html