### PR TITLE
Fix error print for empty files

### DIFF
--- a/src/mctc/io/utils.f90
+++ b/src/mctc/io/utils.f90
@@ -214,6 +214,9 @@ subroutine io_error(error, message, source, token, filename, line, label)
    offset = integer_width(lnum)
    width = token%last - token%first + 1
 
+   ! Fix print alignment for empty files
+   if (offset == 0) offset = 1
+   
    string = "Error: " // message
 
    if (present(filename)) then
@@ -386,8 +389,6 @@ subroutine read_next_token_int(line, pos, token, val, iostat, iomsg)
    integer, intent(out) :: val
    integer, intent(out) :: iostat
    character(len=:), allocatable, intent(out), optional :: iomsg
-
-   character(len=512) :: msg
 
    call next_token(line, pos, token)
    call read_token(line, token, val, iostat, iomsg)


### PR DESCRIPTION
Fixes #63

Now prints:

```sh
[Error]: Error: coordinates not present, cannot work without coordinates
 --> empty.coord:0
  |
0 | 
  |^ unexpected end of input
  |
```