### PR TITLE
Replace OMP reductions by thread-private variables + critical

### DIFF
--- a/src/mctc/ncoord/type.f90
+++ b/src/mctc/ncoord/type.f90
@@ -157,12 +157,18 @@ contains
       integer :: iat, jat, izp, jzp, itr
       real(wp) :: r2, r1, rij(3), countf, cutoff2, den
 
+      ! Thread-private array for reduction
+      real(wp), allocatable :: cn_local(:)
+
       cn(:) = 0.0_wp
       cutoff2 = self%cutoff**2
 
-      !$omp parallel do schedule(runtime) default(none) reduction(+:cn) &
-      !$omp shared(self, mol, trans, cutoff2) &
-      !$omp private(jat, itr, izp, jzp, r2, rij, r1, den, countf)
+      !$omp parallel default(none) &
+      !$omp shared(self, mol, trans, cutoff2, cn) &
+      !$omp private(jat, itr, izp, jzp, r2, rij, r1, den, countf) &
+      !$omp private(cn_local)
+      allocate(cn_local, source=cn)
+      !$omp do schedule(runtime)
       do iat = 1, mol%nat
          izp = mol%id(iat)
          do jat = 1, iat
@@ -177,14 +183,20 @@ contains
 
                countf = den * self%ncoord_count(izp, jzp, r1)
 
-               cn(iat) = cn(iat) + countf
+               cn_local(iat) = cn_local(iat) + countf
                if (iat /= jat) then
-                  cn(jat) = cn(jat) + countf * self%directed_factor
+                  cn_local(jat) = cn_local(jat) + countf * self%directed_factor
                end if
 
             end do
          end do
       end do
+      !$omp end do
+      !$omp critical (ncoord)
+      cn(:) = cn(:) + cn_local(:)
+      !$omp end critical (ncoord)
+      deallocate(cn_local)
+      !$omp end parallel
 
    end subroutine ncoord
 
@@ -205,15 +217,23 @@ contains
       integer :: iat, jat, izp, jzp, itr
       real(wp) :: r2, r1, rij(3), countf, countd(3), sigma(3, 3), cutoff2, den
 
+      ! Thread-private arrays for reduction
+      real(wp), allocatable :: cn_local(:)
+      real(wp), allocatable :: dcndr_local(:, :, :), dcndL_local(:, :, :)
+
       cn(:) = 0.0_wp
       dcndr(:, :, :) = 0.0_wp
       dcndL(:, :, :) = 0.0_wp
       cutoff2 = self%cutoff**2
 
-      !$omp parallel do schedule(runtime) default(none) &
-      !$omp reduction(+:cn, dcndr, dcndL) shared(mol, trans, cutoff2) &
-      !$omp shared(self) &
-      !$omp private(jat, itr, izp, jzp, r2, rij, r1, den, countf, countd, sigma)
+      !$omp parallel default(none) &
+      !$omp shared(self, mol, trans, cutoff2, cn, dcndr, dcndL) &
+      !$omp private(jat, itr, izp, jzp, r2, rij, r1, den, countf, countd) &
+      !$omp private(sigma, cn_local, dcndr_local, dcndL_local)
+      allocate(cn_local, source=cn)
+      allocate(dcndr_local, source=dcndr)
+      allocate(dcndL_local, source=dcndL)
+      !$omp do schedule(runtime)
       do iat = 1, mol%nat
          izp = mol%id(iat)
          do jat = 1, iat
@@ -229,26 +249,34 @@ contains
                countf = den * self%ncoord_count(izp, jzp, r1)
                countd = den * self%ncoord_dcount(izp, jzp, r1) * rij/r1
 
-               cn(iat) = cn(iat) + countf
+               cn_local(iat) = cn_local(iat) + countf
                if (iat /= jat) then
-                  cn(jat) = cn(jat) + countf * self%directed_factor
+                  cn_local(jat) = cn_local(jat) + countf * self%directed_factor
                end if
 
-               dcndr(:, iat, iat) = dcndr(:, iat, iat) + countd
-               dcndr(:, jat, jat) = dcndr(:, jat, jat) - countd * self%directed_factor
-               dcndr(:, iat, jat) = dcndr(:, iat, jat) + countd * self%directed_factor
-               dcndr(:, jat, iat) = dcndr(:, jat, iat) - countd
+               dcndr_local(:, iat, iat) = dcndr_local(:, iat, iat) + countd
+               dcndr_local(:, jat, jat) = dcndr_local(:, jat, jat) - countd * self%directed_factor
+               dcndr_local(:, iat, jat) = dcndr_local(:, iat, jat) + countd * self%directed_factor
+               dcndr_local(:, jat, iat) = dcndr_local(:, jat, iat) - countd
 
                sigma = spread(countd, 1, 3) * spread(rij, 2, 3)
 
-               dcndL(:, :, iat) = dcndL(:, :, iat) + sigma
+               dcndL_local(:, :, iat) = dcndL_local(:, :, iat) + sigma
                if (iat /= jat) then
-                  dcndL(:, :, jat) = dcndL(:, :, jat) + sigma * self%directed_factor
+                  dcndL_local(:, :, jat) = dcndL_local(:, :, jat) + sigma * self%directed_factor
                end if
 
             end do
          end do
       end do
+      !$omp end do
+      !$omp critical (ncoord_d)
+      cn(:) = cn(:) + cn_local(:)
+      dcndr(:, :, :) = dcndr(:, :, :) + dcndr_local(:, :, :)
+      dcndL(:, :, :) = dcndL(:, :, :) + dcndL_local(:, :, :)
+      !$omp end critical (ncoord_d)
+      deallocate(cn_local, dcndr_local, dcndL_local)
+      !$omp end parallel
 
    end subroutine ncoord_d
 
@@ -275,13 +303,19 @@ contains
    
       integer :: iat, jat, izp, jzp, itr
       real(wp) :: r2, r1, rij(3), countd(3), ds(3, 3), cutoff2, den
+
+      ! Thread-private arrays for reduction
+      real(wp), allocatable :: gradient_local(:, :), sigma_local(:, :)
    
       cutoff2 = self%cutoff**2
    
-      !$omp parallel do schedule(runtime) default(none) &
-      !$omp reduction(+:gradient, sigma) &
-      !$omp shared(self, mol, trans, cutoff2, dEdcn) &
-      !$omp private(iat, jat, itr, izp, jzp, r2, rij, r1, countd, ds, den)
+      !$omp parallel default(none) &
+      !$omp shared(self, mol, trans, cutoff2, dEdcn, gradient, sigma) &
+      !$omp private(iat, jat, itr, izp, jzp, r2, rij, r1, countd, ds, den) &
+      !$omp private(gradient_local, sigma_local)
+      allocate(gradient_local, source=gradient)
+      allocate(sigma_local, source=sigma)
+      !$omp do schedule(runtime)
       do iat = 1, mol%nat
          izp = mol%id(iat)
          do jat = 1, iat
@@ -296,20 +330,27 @@ contains
 
                countd = den * self%ncoord_dcount(izp, jzp, r1) * rij/r1
 
-               gradient(:, iat) = gradient(:, iat) + countd &
+               gradient_local(:, iat) = gradient_local(:, iat) + countd &
                   & * (dEdcn(iat) + dEdcn(jat) * self%directed_factor)
-               gradient(:, jat) = gradient(:, jat) - countd &
+               gradient_local(:, jat) = gradient_local(:, jat) - countd &
                   & * (dEdcn(iat) + dEdcn(jat) * self%directed_factor)
    
                ds = spread(countd, 1, 3) * spread(rij, 2, 3)
    
-               sigma(:, :) = sigma(:, :) &
+               sigma_local(:, :) = sigma_local(:, :) &
                   & + ds * (dEdcn(iat) + &
                   & merge(dEdcn(jat) * self%directed_factor, 0.0_wp, jat /= iat))
             end do
          end do
       end do
-   
+      !$omp end do
+      !$omp critical (add_coordination_number_derivs)
+      gradient(:, :) = gradient(:, :) + gradient_local(:, :)
+      sigma(:, :) = sigma(:, :) + sigma_local(:, :)
+      !$omp end critical (add_coordination_number_derivs)
+      deallocate(gradient_local, sigma_local)
+      !$omp end parallel
+
    end subroutine add_coordination_number_derivs
 
 

--- a/src/mctc/ncoord/type.f90
+++ b/src/mctc/ncoord/type.f90
@@ -192,9 +192,9 @@ contains
          end do
       end do
       !$omp end do
-      !$omp critical (ncoord)
+      !$omp critical (ncoord_)
       cn(:) = cn(:) + cn_local(:)
-      !$omp end critical (ncoord)
+      !$omp end critical (ncoord_)
       deallocate(cn_local)
       !$omp end parallel
 
@@ -270,11 +270,11 @@ contains
          end do
       end do
       !$omp end do
-      !$omp critical (ncoord_d)
+      !$omp critical (ncoord_d_)
       cn(:) = cn(:) + cn_local(:)
       dcndr(:, :, :) = dcndr(:, :, :) + dcndr_local(:, :, :)
       dcndL(:, :, :) = dcndL(:, :, :) + dcndL_local(:, :, :)
-      !$omp end critical (ncoord_d)
+      !$omp end critical (ncoord_d_)
       deallocate(cn_local, dcndr_local, dcndL_local)
       !$omp end parallel
 
@@ -344,10 +344,10 @@ contains
          end do
       end do
       !$omp end do
-      !$omp critical (add_coordination_number_derivs)
+      !$omp critical (add_coordination_number_derivs_)
       gradient(:, :) = gradient(:, :) + gradient_local(:, :)
       sigma(:, :) = sigma(:, :) + sigma_local(:, :)
-      !$omp end critical (add_coordination_number_derivs)
+      !$omp end critical (add_coordination_number_derivs_)
       deallocate(gradient_local, sigma_local)
       !$omp end parallel
 


### PR DESCRIPTION
Replace reductions on arrays, which can lead to stack overflow errors for large(r) arrays. Reductions on arrays usually require increasing both `OMP_STACKSIZE` for the worker threads, but also setting `ulimit -s unlimited` to allow the stack size of the main thread to grow beyond the limit set upon starting the process. This is because reductions put the arrays on the stack, not on the heap.
We avoid this by creating private copies on the heap for each thread and add up all copies after the loop in a `critical` section, effectively emulating the reduction.