### PR TITLE
Initialize private arrays with zero

### DIFF
--- a/src/mctc/ncoord/type.f90
+++ b/src/mctc/ncoord/type.f90
@@ -308,13 +308,13 @@ contains
       real(wp), allocatable :: gradient_local(:, :), sigma_local(:, :)
    
       cutoff2 = self%cutoff**2
-   
+
       !$omp parallel default(none) &
       !$omp shared(self, mol, trans, cutoff2, dEdcn, gradient, sigma) &
       !$omp private(iat, jat, itr, izp, jzp, r2, rij, r1, countd, ds, den) &
       !$omp private(gradient_local, sigma_local)
-      allocate(gradient_local, source=gradient)
-      allocate(sigma_local, source=sigma)
+      allocate(gradient_local(size(gradient, 1), size(gradient, 2)), source=0.0_wp)
+      allocate(sigma_local(size(sigma, 1), size(sigma, 2)), source=0.0_wp)
       !$omp do schedule(runtime)
       do iat = 1, mol%nat
          izp = mol%id(iat)


### PR DESCRIPTION
In `add_coordination_number_derivs` the gradient and sigma can contain entries from previous contributions (`inout` instead of `out`). Thus, we cannot use them to allocate the private arrays. I added a test to catch errors like this in the future. 