### PR TITLE
Check for unsupported meson version 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 To build this project from the source code in this repository you need to have
 a Fortran compiler supporting Fortran 2008 and one of the supported build systems:
-- [meson](https://mesonbuild.com) version 0.55 or newer, with
+- [meson](https://mesonbuild.com) version 0.55 or newer (except 1.8.0), with
   a build-system backend, *i.e.* [ninja](https://ninja-build.org) version 1.7 or newer
 - [cmake](https://cmake.org) version 3.14 or newer, with
   a build-system backend, *i.e.* [ninja](https://ninja-build.org) version 1.10 or newer

--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,11 @@ project(
 )
 install = not (meson.is_subproject() and get_option('default_library') == 'static')
 
+# Check for specific unsupported meson versions
+if meson.version().version_compare('==1.8.0')
+  error('Meson version 1.8.0 has a known issue — please use any other version ≥ 0.55.0')
+endif
+
 # General configuration information
 lib_deps = []
 subdir('config')


### PR DESCRIPTION
Add check for unsupported meson version 1.8.0 similar to [grimme-lab/multicharge#54](https://github.com/grimme-lab/multicharge/pull/54)