### PR TITLE
Add support for periodic boundary conditions in QCSchema IO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@
 /build*/
 /_*/
 /docs*/
+/subprojects/*/
+/subprojects/test-drive.wrap

--- a/doc/format-qcschema.md
+++ b/doc/format-qcschema.md
@@ -85,6 +85,24 @@ Caffeine molecule in ``qcschema_molecule`` format.
 }
 ```
 
+## Extensions
+
+The reader supports the following extensions:
+
+- Periodic boundary conditions are specified by providing the lattice vectors in Bohr
+  as extras to the molecule in periodic.lattice as flattened array.
+
+```json
+"extras": {
+  "periodic": {
+    "lattice": [
+       5.5900366437622173, 0.0000000000000000, 0.0000000000000000,
+       0.0000000000000000, 8.6808915904526547, 0.0000000000000000,
+       0.0000000000000000, 0.0000000000000000, 8.6808915904526547
+    ]
+  }
+}
+```
 
 ## Missing features
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,7 @@ set(
   "write-genformat"
   "write-pdb"
   "write-qchem"
+  "write-qcschema"
   "write-turbomole"
   "write-vasp"
   "write-xyz"

--- a/test/main.f90
+++ b/test/main.f90
@@ -43,6 +43,7 @@ program tester
    use test_write_genformat, only : collect_write_genformat
    use test_write_pdb, only : collect_write_pdb
    use test_write_qchem, only : collect_write_qchem
+   use test_write_qcschema, only : collect_write_qcschema
    use test_write_turbomole, only : collect_write_turbomole
    use test_write_vasp, only : collect_write_vasp
    use test_write_xyz, only : collect_write_xyz
@@ -80,6 +81,7 @@ program tester
       & new_testsuite("write-genformat", collect_write_genformat), &
       & new_testsuite("write-pdb", collect_write_pdb), &
       & new_testsuite("write-qchem", collect_write_qchem), &
+      & new_testsuite("write-qcschema", collect_write_qcschema), &
       & new_testsuite("write-turbomole", collect_write_turbomole), &
       & new_testsuite("write-vasp", collect_write_vasp), &
       & new_testsuite("write-xyz", collect_write_xyz) &

--- a/test/meson.build
+++ b/test/meson.build
@@ -38,6 +38,7 @@ tests = [
   'write-genformat',
   'write-pdb',
   'write-qchem',
+  'write-qcschema',
   'write-turbomole',
   'write-vasp',
   'write-xyz',

--- a/test/test_read_qcschema.f90
+++ b/test/test_read_qcschema.f90
@@ -67,7 +67,8 @@ subroutine collect_read_qcschema(testsuite)
       & new_unittest("invalid-schema-name-type2", test_invalid_schema_name_type2, should_fail=.true.), &
       & new_unittest("invalid-root-data", test_invalid_root_data, should_fail=.true.), &
       & new_unittest("extras-incomplete-lattice", test_extras_incomplete_lattice, should_fail=.true.), &
-      & new_unittest("extras-incompatible-lattice", test_extras_incompatible_lattice, should_fail=.true.), &
+      & new_unittest("extras-incompatible-lattice1", test_extras_incompatible_lattice1, should_fail=.true.), &
+      & new_unittest("extras-incompatible-lattice2", test_extras_incompatible_lattice2, should_fail=.true.), &
       & new_unittest("extras-incompatible-periodic", test_extras_incompatible_periodic, should_fail=.true.), &
       & new_unittest("extras-type-mismatch", test_extras_type_mismatch, should_fail=.true.), &
       & new_unittest("cjson", test_cjson_qcschema, should_fail=.true.) &
@@ -1318,7 +1319,7 @@ subroutine test_extras_incomplete_lattice(error)
 end subroutine test_extras_incomplete_lattice
 
 
-subroutine test_extras_incompatible_lattice(error)
+subroutine test_extras_incompatible_lattice1(error)
 
    !> Error handling
    type(error_type), allocatable, intent(out) :: error
@@ -1365,7 +1366,60 @@ subroutine test_extras_incompatible_lattice(error)
    close(unit, status='delete')
    if (allocated(error)) return
 
-end subroutine test_extras_incompatible_lattice
+end subroutine test_extras_incompatible_lattice1
+
+
+subroutine test_extras_incompatible_lattice2(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   character(len=*), parameter :: filename = ".test-valid5-qcschema.json"
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(file=filename, newunit=unit)
+   write(unit, '(a)') &
+      '{', &
+      '  "schema_version": 2,', &
+      '  "schema_name": "qcschema_molecule",', &
+      '  "provenance": {', &
+      '    "creator": "mctc-lib",', &
+      '    "version": "0.4.2",', &
+      '    "routine": "mctc_io_write_qcschema::write_qcschema"', &
+      '  },', &
+      '  "comment": "TiO2 rutile",', &
+      '  "symbols": ["Ti", "Ti", "O", "O", "O", "O"],', &
+      '  "atomic_numbers": [22, 22, 8, 8, 8, 8],', &
+      '  "geometry": [', &
+      '     0.0000000000000000E+00, 0.0000000000000000E+00, 0.0000000000000000E+00,', &
+      '     5.2818191416515159E+00, 8.2022538117381334E+00, 8.2022538117381334E+00,', &
+      '     6.1333938828927657E-16, 5.0082961774473045E+00, 5.0082961774473045E+00,', &
+      '     1.3956333869785798E-15, 1.1396211446028962E+01, 1.1396211446028962E+01,', &
+      '     5.2818191416515150E+00, 3.1939576342908298E+00, 1.3210549989185438E+01,', &
+      '     5.2818191416515150E+00, 1.3210549989185438E+01, 3.1939576342908289E+00', &
+      '  ],', &
+      '  "molecular_charge": 0,', &
+      '  "extras": {', &
+      '    "periodic": {', &
+      '      "lattice": {', &
+      '         "a": 5.5900366437622173E+00,', &
+      '         "b": 8.6808915904526547E+00,', &
+      '         "c": 8.6808915904526547E+00,', &
+      '         "alpha": 90.0,', &
+      '         "beta":  90.0,', &
+      '         "gamma": 90.0', &
+      '      ]', &
+      '    }', &
+      '  }', &
+      '}'
+   rewind(unit)
+
+   call read_qcschema(struc, unit, error)
+   close(unit, status='delete')
+   if (allocated(error)) return
+
+end subroutine test_extras_incompatible_lattice2
 
 
 subroutine test_extras_incompatible_periodic(error)

--- a/test/test_read_qcschema.f90
+++ b/test/test_read_qcschema.f90
@@ -42,6 +42,7 @@ subroutine collect_read_qcschema(testsuite)
       & new_unittest("valid3-qcschema", test_valid3_qcschema, should_fail=.not.with_json), &
       & new_unittest("valid4-qcschema", test_valid4_qcschema, should_fail=.not.with_json), &
       & new_unittest("valid5-qcschema", test_valid5_qcschema, should_fail=.not.with_json), &
+      & new_unittest("extras1-qcschema", test_extras1_qcschema, should_fail=.not.with_json), &
       & new_unittest("incomplete", test_incomplete, should_fail=.true.), &
       & new_unittest("mismatch-schema", test_mismatch_schema, should_fail=.true.), &
       & new_unittest("mismatch-geometry-symbols", test_mismatch_geometry_symbols, should_fail=.true.), &
@@ -65,6 +66,10 @@ subroutine collect_read_qcschema(testsuite)
       & new_unittest("invalid-schema-name-type1", test_invalid_schema_name_type1, should_fail=.true.), &
       & new_unittest("invalid-schema-name-type2", test_invalid_schema_name_type2, should_fail=.true.), &
       & new_unittest("invalid-root-data", test_invalid_root_data, should_fail=.true.), &
+      & new_unittest("extras-incomplete-lattice", test_extras_incomplete_lattice, should_fail=.true.), &
+      & new_unittest("extras-incompatible-lattice", test_extras_incompatible_lattice, should_fail=.true.), &
+      & new_unittest("extras-incompatible-periodic", test_extras_incompatible_periodic, should_fail=.true.), &
+      & new_unittest("extras-type-mismatch", test_extras_type_mismatch, should_fail=.true.), &
       & new_unittest("cjson", test_cjson_qcschema, should_fail=.true.) &
       & ]
 
@@ -372,7 +377,8 @@ subroutine test_valid5_qcschema(error)
       '  ],', &
       '  "symbols": ["O", "H", "H"],', &
       '  "connectivity": [[ 0, 1, 1],  [ 0, 2, 1]],', &
-      '  "comment": "Water molecule"', &
+      '  "comment": "Water molecule",', &
+      '  "extras": null', &
       '}'
    rewind(unit)
 
@@ -390,6 +396,67 @@ subroutine test_valid5_qcschema(error)
    if (allocated(error)) return
 
 end subroutine test_valid5_qcschema
+
+
+subroutine test_extras1_qcschema(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   character(len=*), parameter :: filename = ".test-valid5-qcschema.json"
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(file=filename, newunit=unit)
+   write(unit, '(a)') &
+      '{', &
+      '  "schema_version": 2,', &
+      '  "schema_name": "qcschema_molecule",', &
+      '  "provenance": {', &
+      '    "creator": "mctc-lib",', &
+      '    "version": "0.4.2",', &
+      '    "routine": "mctc_io_write_qcschema::write_qcschema"', &
+      '  },', &
+      '  "comment": "TiO2 rutile",', &
+      '  "symbols": ["Ti", "Ti", "O", "O", "O", "O"],', &
+      '  "atomic_numbers": [22, 22, 8, 8, 8, 8],', &
+      '  "geometry": [', &
+      '     0.0000000000000000E+00, 0.0000000000000000E+00, 0.0000000000000000E+00,', &
+      '     5.2818191416515159E+00, 8.2022538117381334E+00, 8.2022538117381334E+00,', &
+      '     6.1333938828927657E-16, 5.0082961774473045E+00, 5.0082961774473045E+00,', &
+      '     1.3956333869785798E-15, 1.1396211446028962E+01, 1.1396211446028962E+01,', &
+      '     5.2818191416515150E+00, 3.1939576342908298E+00, 1.3210549989185438E+01,', &
+      '     5.2818191416515150E+00, 1.3210549989185438E+01, 3.1939576342908289E+00', &
+      '  ],', &
+      '  "molecular_charge": 0,', &
+      '  "extras": {', &
+      '    "periodic": {', &
+      '      "lattice": [', &
+      '         5.5900366437622173E+00, 0.0000000000000000E+00, 0.0000000000000000E+00,', &
+      '         5.3155130499965102E-16, 8.6808915904526547E+00, 0.0000000000000000E+00,', &
+      '         5.3155130499965102E-16, 5.3155130499965102E-16, 8.6808915904526547E+00', &
+      '      ]', &
+      '    }', &
+      '  }', &
+      '}'
+   rewind(unit)
+
+   call read_qcschema(struc, unit, error)
+   close(unit, status='delete')
+   if (allocated(error)) return
+
+   call check(error, allocated(struc%comment), "Comment line should be preserved")
+   if (allocated(error)) return
+   call check(error, struc%comment, "TiO2 rutile")
+   if (allocated(error)) return
+   call check(error, struc%nat, 6, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 2, "Number of species does not match")
+   if (allocated(error)) return
+   call check(error, all(struc%periodic), .true., "Structure should be periodic")
+   if (allocated(error)) return
+
+end subroutine test_extras1_qcschema
 
 
 subroutine test_mismatch_schema(error)
@@ -1202,5 +1269,188 @@ subroutine test_cjson_qcschema(error)
 
 end subroutine test_cjson_qcschema
 
+
+subroutine test_extras_incomplete_lattice(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   character(len=*), parameter :: filename = ".test-valid5-qcschema.json"
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(file=filename, newunit=unit)
+   write(unit, '(a)') &
+      '{', &
+      '  "schema_version": 2,', &
+      '  "schema_name": "qcschema_molecule",', &
+      '  "provenance": {', &
+      '    "creator": "mctc-lib",', &
+      '    "version": "0.4.2",', &
+      '    "routine": "mctc_io_write_qcschema::write_qcschema"', &
+      '  },', &
+      '  "comment": "TiO2 rutile",', &
+      '  "symbols": ["Ti", "Ti", "O", "O", "O", "O"],', &
+      '  "atomic_numbers": [22, 22, 8, 8, 8, 8],', &
+      '  "geometry": [', &
+      '     0.0000000000000000E+00, 0.0000000000000000E+00, 0.0000000000000000E+00,', &
+      '     5.2818191416515159E+00, 8.2022538117381334E+00, 8.2022538117381334E+00,', &
+      '     6.1333938828927657E-16, 5.0082961774473045E+00, 5.0082961774473045E+00,', &
+      '     1.3956333869785798E-15, 1.1396211446028962E+01, 1.1396211446028962E+01,', &
+      '     5.2818191416515150E+00, 3.1939576342908298E+00, 1.3210549989185438E+01,', &
+      '     5.2818191416515150E+00, 1.3210549989185438E+01, 3.1939576342908289E+00', &
+      '  ],', &
+      '  "molecular_charge": 0,', &
+      '  "extras": {', &
+      '    "periodic": {', &
+      '      "lattice": [', &
+      '         5.5900366437622173E+00, 8.6808915904526547E+00, 8.6808915904526547E+00', &
+      '      ]', &
+      '    }', &
+      '  }', &
+      '}'
+   rewind(unit)
+
+   call read_qcschema(struc, unit, error)
+   close(unit, status='delete')
+   if (allocated(error)) return
+
+end subroutine test_extras_incomplete_lattice
+
+
+subroutine test_extras_incompatible_lattice(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   character(len=*), parameter :: filename = ".test-valid5-qcschema.json"
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(file=filename, newunit=unit)
+   write(unit, '(a)') &
+      '{', &
+      '  "schema_version": 2,', &
+      '  "schema_name": "qcschema_molecule",', &
+      '  "provenance": {', &
+      '    "creator": "mctc-lib",', &
+      '    "version": "0.4.2",', &
+      '    "routine": "mctc_io_write_qcschema::write_qcschema"', &
+      '  },', &
+      '  "comment": "TiO2 rutile",', &
+      '  "symbols": ["Ti", "Ti", "O", "O", "O", "O"],', &
+      '  "atomic_numbers": [22, 22, 8, 8, 8, 8],', &
+      '  "geometry": [', &
+      '     0.0000000000000000E+00, 0.0000000000000000E+00, 0.0000000000000000E+00,', &
+      '     5.2818191416515159E+00, 8.2022538117381334E+00, 8.2022538117381334E+00,', &
+      '     6.1333938828927657E-16, 5.0082961774473045E+00, 5.0082961774473045E+00,', &
+      '     1.3956333869785798E-15, 1.1396211446028962E+01, 1.1396211446028962E+01,', &
+      '     5.2818191416515150E+00, 3.1939576342908298E+00, 1.3210549989185438E+01,', &
+      '     5.2818191416515150E+00, 1.3210549989185438E+01, 3.1939576342908289E+00', &
+      '  ],', &
+      '  "molecular_charge": 0,', &
+      '  "extras": {', &
+      '    "periodic": {', &
+      '      "lattice": [', &
+      '         [5.5900366437622173E+00, 0.0000000000000000E+00, 0.0000000000000000E+00],', &
+      '         [5.3155130499965102E-16, 8.6808915904526547E+00, 0.0000000000000000E+00],', &
+      '         [5.3155130499965102E-16, 5.3155130499965102E-16, 8.6808915904526547E+00]', &
+      '      ]', &
+      '    }', &
+      '  }', &
+      '}'
+   rewind(unit)
+
+   call read_qcschema(struc, unit, error)
+   close(unit, status='delete')
+   if (allocated(error)) return
+
+end subroutine test_extras_incompatible_lattice
+
+
+subroutine test_extras_incompatible_periodic(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   character(len=*), parameter :: filename = ".test-valid5-qcschema.json"
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(file=filename, newunit=unit)
+   write(unit, '(a)') &
+      '{', &
+      '  "schema_version": 2,', &
+      '  "schema_name": "qcschema_molecule",', &
+      '  "provenance": {', &
+      '    "creator": "mctc-lib",', &
+      '    "version": "0.4.2",', &
+      '    "routine": "mctc_io_write_qcschema::write_qcschema"', &
+      '  },', &
+      '  "comment": "TiO2 rutile",', &
+      '  "symbols": ["Ti", "Ti", "O", "O", "O", "O"],', &
+      '  "atomic_numbers": [22, 22, 8, 8, 8, 8],', &
+      '  "geometry": [', &
+      '     0.0000000000000000E+00, 0.0000000000000000E+00, 0.0000000000000000E+00,', &
+      '     5.2818191416515159E+00, 8.2022538117381334E+00, 8.2022538117381334E+00,', &
+      '     6.1333938828927657E-16, 5.0082961774473045E+00, 5.0082961774473045E+00,', &
+      '     1.3956333869785798E-15, 1.1396211446028962E+01, 1.1396211446028962E+01,', &
+      '     5.2818191416515150E+00, 3.1939576342908298E+00, 1.3210549989185438E+01,', &
+      '     5.2818191416515150E+00, 1.3210549989185438E+01, 3.1939576342908289E+00', &
+      '  ],', &
+      '  "molecular_charge": 0,', &
+      '  "extras": {', &
+      '    "periodic": 3', &
+      '  }', &
+      '}'
+   rewind(unit)
+
+   call read_qcschema(struc, unit, error)
+   close(unit, status='delete')
+   if (allocated(error)) return
+
+end subroutine test_extras_incompatible_periodic
+
+
+subroutine test_extras_type_mismatch(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   character(len=*), parameter :: filename = ".test-valid5-qcschema.json"
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(file=filename, newunit=unit)
+   write(unit, '(a)') &
+      '{', &
+      '  "schema_version": 2,', &
+      '  "schema_name": "qcschema_molecule",', &
+      '  "provenance": {', &
+      '    "creator": "mctc-lib",', &
+      '    "version": "0.4.2",', &
+      '    "routine": "mctc_io_write_qcschema::write_qcschema"', &
+      '  },', &
+      '  "comment": "TiO2 rutile",', &
+      '  "symbols": ["Ti", "Ti", "O", "O", "O", "O"],', &
+      '  "atomic_numbers": [22, 22, 8, 8, 8, 8],', &
+      '  "geometry": [', &
+      '     0.0000000000000000E+00, 0.0000000000000000E+00, 0.0000000000000000E+00,', &
+      '     5.2818191416515159E+00, 8.2022538117381334E+00, 8.2022538117381334E+00,', &
+      '     6.1333938828927657E-16, 5.0082961774473045E+00, 5.0082961774473045E+00,', &
+      '     1.3956333869785798E-15, 1.1396211446028962E+01, 1.1396211446028962E+01,', &
+      '     5.2818191416515150E+00, 3.1939576342908298E+00, 1.3210549989185438E+01,', &
+      '     5.2818191416515150E+00, 1.3210549989185438E+01, 3.1939576342908289E+00', &
+      '  ],', &
+      '  "molecular_charge": 0,', &
+      '  "extras": true', &
+      '}'
+   rewind(unit)
+
+   call read_qcschema(struc, unit, error)
+   close(unit, status='delete')
+   if (allocated(error)) return
+
+end subroutine test_extras_type_mismatch
 
 end module test_read_qcschema

--- a/test/test_write_qcschema.f90
+++ b/test/test_write_qcschema.f90
@@ -1,0 +1,108 @@
+! This file is part of mctc-lib.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+module test_write_qcschema
+   use mctc_env_testing, only : new_unittest, unittest_type, error_type, check
+   use testsuite_structure, only : get_structure
+   use mctc_io_write_qcschema
+   use mctc_io_read_qcschema
+   use mctc_io_structure
+   use mctc_version, only : get_mctc_feature
+   implicit none
+   private
+
+   public :: collect_write_qcschema
+
+
+contains
+
+
+!> Collect all exported unit tests
+subroutine collect_write_qcschema(testsuite)
+
+   !> Collection of tests
+   type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+   logical :: with_json
+
+   with_json = get_mctc_feature("json")
+
+   testsuite = [ &
+      & new_unittest("valid1-qcschema", test_valid1_qcschema, should_fail=.not.with_json), &
+      & new_unittest("valid2-qcschema", test_valid2_qcschema, should_fail=.not.with_json) &
+      & ]
+
+end subroutine collect_write_qcschema
+
+
+subroutine test_valid1_qcschema(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit, nat, nid
+
+   call get_structure(struc, "mindless01")
+   struc%comment = "mindless"
+   nat = struc%nat
+   nid = struc%nid
+
+   open(status='scratch', newunit=unit)
+   call write_qcschema(struc, unit)
+   rewind(unit)
+
+   call read_qcschema(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%comment, "mindless", "Comment no preserved")
+   if (allocated(error)) return
+   call check(error, struc%nat, nat, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, nid, "Number of species does not match")
+   if (allocated(error)) return
+
+end subroutine test_valid1_qcschema
+
+
+subroutine test_valid2_qcschema(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit, nat, nid
+
+   call get_structure(struc, "x01")
+   nat = struc%nat
+   nid = struc%nid
+
+   open(status='scratch', newunit=unit)
+   call write_qcschema(struc, unit)
+   rewind(unit)
+
+   call read_qcschema(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, nat, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, nid, "Number of species does not match")
+   if (allocated(error)) return
+
+end subroutine test_valid2_qcschema
+
+
+end module test_write_qcschema


### PR DESCRIPTION
See https://github.com/MolSSI/QCSchema/issues/86, https://github.com/MolSSI/QCSchema/issues/66

Example:

````json
{
  "schema_version": 2,
  "schema_name": "qcschema_molecule",
  "provenance": {
    "creator": "mctc-lib",
    "version": "0.4.2",
    "routine": "mctc_io_write_qcschema::write_qcschema"
  },
  "comment": "TiO2 rutile",
  "symbols": [
    "Ti",
    "Ti",
    "O",
    "O",
    "O",
    "O"
  ],
  "atomic_numbers": [
    22,
    22,
    8,
    8,
    8,
    8
  ],
  "geometry": [
     0.0000000000000000E+00,
     0.0000000000000000E+00,
     0.0000000000000000E+00,
     5.2818191416515159E+00,
     8.2022538117381334E+00,
     8.2022538117381334E+00,
     6.1333938828927657E-16,
     5.0082961774473045E+00,
     5.0082961774473045E+00,
     1.3956333869785798E-15,
     1.1396211446028962E+01,
     1.1396211446028962E+01,
     5.2818191416515150E+00,
     3.1939576342908298E+00,
     1.3210549989185438E+01,
     5.2818191416515150E+00,
     1.3210549989185438E+01,
     3.1939576342908289E+00
  ],
  "molecular_charge": 0,
  "extras": {
    "periodic": {
      "lattice": [
         5.5900366437622173E+00,
         0.0000000000000000E+00,
         0.0000000000000000E+00,
         5.3155130499965102E-16,
         8.6808915904526547E+00,
         0.0000000000000000E+00,
         5.3155130499965102E-16,
         5.3155130499965102E-16,
         8.6808915904526547E+00
      ]
    }
  }
}
````