### PR TITLE
Allow for dynamically determining JSON schema of input

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,47 @@
 [![codecov](https://codecov.io/gh/grimme-lab/mctc-lib/branch/main/graph/badge.svg)](https://codecov.io/gh/grimme-lab/mctc-lib)
 
 
+## Supported formats
+
+This library supports reading and writing in more than ten different geometry formats, including general ASCII formats, like xyz, JSON based formats, like QCSchema, and program specific formats, for example compatible with Turbomole or Vasp.
+
+*General geometry formats*
+
+- [xyz][xyz] file format with ``xyz`` extension
+- [Protein data base][pdb] file format with ``pdb`` extension
+- [mol][ctfile] and [structure data][ctfile] connection table file formats with ``mol`` and ``sdf`` extension, respectively
+
+[xyz]: http://www.ccl.net/chemistry/resources/messages/1996/10/21.005-dir/index.html
+[pdb]: http://www.wwpdb.org/documentation/file-format-content/format33/v3.3.html
+[ctfile]: https://www.daylight.com/meetings/mug05/Kappler/ctfile.pdf
+
+*JSON based formats*
+
+- [Pymatgen JSON][pmg] with ``pmgjson`` or ``json`` extension
+- [QCSchema JSON][qcsk] with ``qcjson`` or ``json`` extension
+- [Chemical JSON][cjson] with ``cjson`` or ``json`` extension
+
+[pmg]: https://pymatgen.org
+[qcsk]: https://molssi-qc-schema.readthedocs.io
+[cjson]: https://github.com/OpenChemistry/avogadrolibs/blob/master/avogadro/io/cjsonformat.cpp
+
+*Program specific formats*
+
+- [Q-Chem molecule][qchem] file format with ``qchem`` extension
+- [Turbomole coord][tmol] file format with ``tmol`` or ``coord`` extension
+- [VASP POSCAR and CONTCAR][vasp] files with ``vasp``, ``poscar``, or ``contcar`` extension
+- [DFTB+ gen][gen] format with ``gen`` extension
+- [Gaussian external][ein] format with ``ein`` extension
+- [FHI-aims][aims] ``geometry.in`` input files
+
+[aims]: https://fhi-aims.org
+[qchem]: https://manual.q-chem.com
+[tmol]: https://www.turbomole.org
+[gen]: https://dftbplus.org
+[ein]: https://gaussian.com/external/
+[vasp]: https://www.vasp.at/wiki/index.php
+
+
 ## Installation
 
 To build this project from the source code in this repository you need to have

--- a/doc/format-cjson.md
+++ b/doc/format-cjson.md
@@ -6,7 +6,7 @@ title: Chemical JSON
 
 @Note [Reference](https://github.com/OpenChemistry/avogadrolibs/blob/master/avogadro/io/cjsonformat.cpp)
 
-Chemical JSON files are identified by the extension ``cjson`` and parsed following the format implemented in Avogadro 2.
+Chemical JSON files are identified by the extension ``cjson`` or ``json`` and parsed following the format implemented in Avogadro 2.
 The entries *name*, *atoms.elements.number*, *atoms.coords.3d*, *atoms.coords.3d fractional*, *unit cell*, *atoms.formalCharges*, *bonds.connections.index*, and *bonds.order* are recognized by the reader.
 
 

--- a/doc/format-pymatgen.md
+++ b/doc/format-pymatgen.md
@@ -6,7 +6,7 @@ title: Pymatgen JSON
 
 @Note [Reference](https://pymatgen.org)
 
-Pymatgen formatted JSON files are identified by the extension ``pmgjson`` and parsed following the ``Molecule`` or ``Structure`` format.
+Pymatgen formatted JSON files are identified by the extension ``pmgjson`` or ``json`` and parsed following the ``Molecule`` or ``Structure`` format.
 
 
 ## Example

--- a/doc/format-qcschema.md
+++ b/doc/format-qcschema.md
@@ -6,7 +6,7 @@ title: QCSchema JSON
 
 @Note [Reference](https://molssi-qc-schema.readthedocs.io)
 
-JSON files are identified by the extension ``json`` and parsed following the ``qcschema_molecule`` or ``qcschema_input`` format.
+JSON files are identified by the extension ``qcjson`` or ``json`` and parsed following the ``qcschema_molecule`` or ``qcschema_input`` format.
 The ``molecule`` entry from a ``qcschema_input`` will be extracted, but there is no guarantee that the input information will be used by the program.
 
 

--- a/man/mctc-convert.1.adoc
+++ b/man/mctc-convert.1.adoc
@@ -26,9 +26,9 @@ Supported formats:
 - Protein Database files, only single files (pdb)
 - Connection table files, molfile (mol) and structure data format (sdf)
 - Gaussian's external program input (ein)
-- JSON input with `qcschema_molecule` or `qcschema_input` structure (json)
-- Chemical JSON input (cjson)
-- Pymatgen JSON with `Molecule` or `Structure` schema (pmgjson)
+- JSON input with `qcschema_molecule` or `qcschema_input` structure (qcjson, json)
+- Chemical JSON input (cjson, json)
+- Pymatgen JSON with `Molecule` or `Structure` schema (pmgjson, json)
 - FHI-AIMS' input files (geometry.in)
 - Q-Chem molecule block inputs (qchem)
 

--- a/src/mctc/io/filetype.f90
+++ b/src/mctc/io/filetype.f90
@@ -66,6 +66,9 @@ module mctc_io_filetype
       !> Pymatgen JSON format
       integer :: pymatgen = 13
 
+      !> General JSON format
+      integer :: json = 14
+
    end type enum_filetype
 
    !> File type enumerator
@@ -107,7 +110,7 @@ elemental function get_filetype(file) result(ftype)
          ftype = filetype%gen
       case('ein')
          ftype = filetype%gaussian
-      case('json')
+      case('qcjson')
          ftype = filetype%qcschema
       case('cjson')
          ftype = filetype%cjson
@@ -115,6 +118,8 @@ elemental function get_filetype(file) result(ftype)
          ftype = filetype%qchem
       case('pmgjson')
          ftype = filetype%pymatgen
+      case('json')
+         ftype = filetype%json
       end select
       if (ftype /= filetype%unknown) return
    else

--- a/src/mctc/io/read.f90
+++ b/src/mctc/io/read.f90
@@ -20,6 +20,7 @@ module mctc_io_read
    use mctc_io_read_ctfile, only : read_molfile, read_sdf
    use mctc_io_read_gaussian, only : read_gaussian_external
    use mctc_io_read_genformat, only : read_genformat
+   use mctc_io_read_json, only : read_json
    use mctc_io_read_qchem, only : read_qchem
    use mctc_io_read_qcschema, only : read_qcschema
    use mctc_io_read_pdb, only : read_pdb
@@ -180,6 +181,9 @@ subroutine get_structure_reader(reader, ftype)
 
    case(filetype%qchem)
       reader => read_qchem
+
+   case(filetype%json)
+      reader => read_json
 
    end select
 

--- a/src/mctc/io/read/CMakeLists.txt
+++ b/src/mctc/io/read/CMakeLists.txt
@@ -21,6 +21,7 @@ list(
   "${dir}/ctfile.f90"
   "${dir}/gaussian.f90"
   "${dir}/genformat.f90"
+  "${dir}/json.F90"
   "${dir}/qchem.f90"
   "${dir}/qcschema.F90"
   "${dir}/pdb.f90"

--- a/src/mctc/io/read/json.F90
+++ b/src/mctc/io/read/json.F90
@@ -1,0 +1,96 @@
+! This file is part of mctc-lib.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+#include "mctc/defs.h"
+
+module mctc_io_read_json
+   use mctc_env_accuracy, only : wp
+   use mctc_env_error, only : error_type, fatal_error
+   use mctc_io_structure, only : structure_type, new
+   use mctc_io_symbols, only : to_number, symbol_length
+   use mctc_io_utils, only : to_string
+   use mctc_io_read_cjson, only : read_cjson
+   use mctc_io_read_qcschema, only : read_qcschema
+   use mctc_io_read_pymatgen, only : read_pymatgen
+#if WITH_JSON
+   use jonquil, only : json_value, json_object, json_array, json_keyval, &
+      & json_load, json_error, json_context, json_stat, get_value, &
+      & json_parser_config, json_context, cast_to_object, len
+#endif
+   implicit none
+   private
+
+   public :: read_json
+
+
+contains
+
+
+subroutine read_json(self, unit, error)
+
+   !> Instance of the molecular structure data
+   type(structure_type), intent(out) :: self
+
+   !> File handle
+   integer, intent(in) :: unit
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+#if WITH_JSON
+   class(json_value), allocatable :: root
+   type(json_object), pointer :: object
+   type(json_error), allocatable :: parse_error
+   type(json_context) :: ctx
+
+   call json_load(root, unit, config=json_parser_config(context_detail=1), &
+      & context=ctx, error=parse_error)
+   if (allocated(parse_error)) then
+      allocate(error)
+      call move_alloc(parse_error%message, error%message)
+      return
+   end if
+   object => cast_to_object(root)
+   if (.not.associated(object)) then
+      call fatal_error(error, ctx%report("Invalid JSON object", root%origin, "Expected JSON object"))
+      return
+   end if
+
+   ! QCSchema JSON uses "schema_name" and "schema_version" keys
+   if (object%has_key("schema_name") .or. object%has_key("schema_version")) then
+      call read_qcschema(self, object, ctx, error)
+      return
+   end if
+
+   ! Pymatgen serialized via monty adds "@module" and "@class" keys
+   if (object%has_key("@module") .or. object%has_key("@class")) then
+      call read_pymatgen(self, object, ctx, error)
+      return
+   end if
+
+   ! Chemical JSON (cjson) tracks version via "chemical json" or "chemicalJson" keys
+   if (object%has_key("chemical json") .or. object%has_key("chemicalJson")) then
+      call read_cjson(self, object, ctx, error)
+      return
+   end if
+
+   ! Default to QCSchema if no specific schema is detected
+   call read_qcschema(self, object, ctx, error)
+#else
+   call fatal_error(error, "JSON support not enabled")
+#endif
+end subroutine read_json
+
+
+end module mctc_io_read_json

--- a/src/mctc/io/read/meson.build
+++ b/src/mctc/io/read/meson.build
@@ -18,6 +18,7 @@ srcs += files(
   'ctfile.f90',
   'gaussian.f90',
   'genformat.f90',
+  'json.F90',
   'qchem.f90',
   'qcschema.F90',
   'pdb.f90',

--- a/src/mctc/io/write.f90
+++ b/src/mctc/io/write.f90
@@ -139,7 +139,7 @@ subroutine write_structure_to_unit(self, unit, ftype, error)
    case(filetype%cjson)
       call write_cjson(self, unit)
 
-   case(filetype%qcschema)
+   case(filetype%qcschema, filetype%json)
       call write_qcschema(self, unit)
 
    case(filetype%aims)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(
   "read-ctfile"
   "read-gaussian"
   "read-genformat"
+  "read-json"
   "read-pdb"
   "read-pymatgen"
   "read-qchem"

--- a/test/main.f90
+++ b/test/main.f90
@@ -28,6 +28,7 @@ program tester
    use test_read_ctfile, only : collect_read_ctfile
    use test_read_gaussian, only : collect_read_gaussian
    use test_read_genformat, only : collect_read_genformat
+   use test_read_json, only : collect_read_json
    use test_read_pdb, only : collect_read_pdb
    use test_read_pymatgen, only : collect_read_pymatgen
    use test_read_qchem, only : collect_read_qchem
@@ -69,6 +70,7 @@ program tester
       & new_testsuite("read-ctfile", collect_read_ctfile), &
       & new_testsuite("read-gaussian", collect_read_gaussian), &
       & new_testsuite("read-genformat", collect_read_genformat), &
+      & new_testsuite("read-json", collect_read_json), &
       & new_testsuite("read-pdb", collect_read_pdb), &
       & new_testsuite("read-pymatgen", collect_read_pymatgen), &
       & new_testsuite("read-qchem", collect_read_qchem), &

--- a/test/meson.build
+++ b/test/meson.build
@@ -23,6 +23,7 @@ tests = [
   'read-ctfile',
   'read-gaussian',
   'read-genformat',
+  'read-json',
   'read-pdb',
   'read-pymatgen',
   'read-qchem',

--- a/test/test_read_json.f90
+++ b/test/test_read_json.f90
@@ -1,0 +1,451 @@
+! This file is part of mctc-lib.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+module test_read_json
+   use mctc_env_testing, only : new_unittest, unittest_type, error_type, check
+   use mctc_io_read_json
+   use mctc_io_structure
+   use mctc_version, only : get_mctc_feature
+   implicit none
+   private
+
+   public :: collect_read_json
+
+
+contains
+
+
+!> Collect all exported unit tests
+subroutine collect_read_json(testsuite)
+
+   !> Collection of tests
+   type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+   logical :: with_json
+
+   with_json = get_mctc_feature("json")
+
+   testsuite = [ &
+      & new_unittest("valid-pymatgen-mol", test_valid_mol1, should_fail=.not.with_json), &
+      & new_unittest("valid-cjson-mol", test_valid_mol2, should_fail=.not.with_json), &
+      & new_unittest("valid-qcschema-mol", test_valid_mol3, should_fail=.not.with_json), &
+      & new_unittest("valid-pymatgen-sol", test_valid_sol1, should_fail=.not.with_json), &
+      & new_unittest("valid-cjson-sol", test_valid_sol2, should_fail=.not.with_json), &
+      & new_unittest("valid-qcschema-sol", test_valid_sol3, should_fail=.not.with_json) &
+      & ]
+
+end subroutine collect_read_json
+
+
+subroutine test_valid_mol1(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   character(len=*), parameter :: filename = ".test-general-pmg-mol1.json"
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(file=filename, newunit=unit)
+   write(unit, '(a)') &
+      '{', &
+      '  "@module": "pymatgen.core.structure",', &
+      '  "@class": "Molecule",', &
+      '  "charge": 0,', &
+      '  "spin_multiplicity": 1,', &
+      '  "sites": [', &
+      '    {', &
+      '      "name": "O",', &
+      '      "species": [{"element": "O", "occu": 1}],', &
+      '      "xyz": [1.1847029, 1.1150792, -0.0344641],', &
+      '      "properties": {},', &
+      '      "label": "O"', &
+      '    },', &
+      '    {', &
+      '      "name": "H",', &
+      '      "species": [{"element": "H", "occu": 1}],', &
+      '      "xyz": [0.4939088, 0.9563767, 0.6340089],', &
+      '      "properties": {},', &
+      '      "label": "H"', &
+      '    },', &
+      '    {', &
+      '      "name": "H",', &
+      '      "species": [{"element": "H", "occu": 1}],', &
+      '      "xyz": [2.0242676, 1.0811246, 0.4301417],', &
+      '      "properties": {},', &
+      '      "label": "H"', &
+      '    },', &
+      '    {', &
+      '      "name": "O",', &
+      '      "species": [{"element": "O", "occu": 1}],', &
+      '      "xyz": [-1.1469443, 0.0697649, 1.1470196],', &
+      '      "properties": {},', &
+      '      "label": "O"', &
+      '    },', &
+      '    {', &
+      '      "name": "H",', &
+      '      "species": [{"element": "H", "occu": 1}],', &
+      '      "xyz": [-1.2798308, -0.5232169, 1.8902833],', &
+      '      "properties": {},', &
+      '      "label": "H"', &
+      '    },', &
+      '    {', &
+      '      "name": "H",', &
+      '      "species": [{"element": "H", "occu": 1}],', &
+      '      "xyz": [-1.0641398, -0.4956693, 0.356925],', &
+      '      "properties": {},', &
+      '      "label": "H"', &
+      '    },', &
+      '    {', &
+      '      "name": "O",', &
+      '      "species": [{"element": "O", "occu": 1}],', &
+      '      "xyz": [-0.1633508, -1.0289346, -1.2401808],', &
+      '      "properties": {},', &
+      '      "label": "O"', &
+      '    },', &
+      '    {', &
+      '      "name": "H",', &
+      '      "species": [{"element": "H", "occu": 1}],', &
+      '      "xyz": [0.4914771, -0.3248733, -1.0784838],', &
+      '      "properties": {},', &
+      '      "label": "H"', &
+      '    },', &
+      '    {', &
+      '      "name": "H",', &
+      '      "species": [{"element": "H", "occu": 1}],', &
+      '      "xyz": [-0.5400907, -0.8496512, -2.1052499],', &
+      '      "properties": {},', &
+      '      "label": "H"', &
+      '    }', &
+      '  ],', &
+      '  "properties": {}', &
+      '}'
+   rewind(unit)
+
+   call read_json(struc, unit, error)
+   close(unit, status='delete')
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 9, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 2, "Number of species does not match")
+   if (allocated(error)) return
+
+end subroutine test_valid_mol1
+
+subroutine test_valid_mol2(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   character(len=*), parameter :: filename = ".test-general-cjson-mol2.json"
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(file=filename, newunit=unit)
+   write(unit, '(a)') &
+      '{', &
+      '  "chemicalJson": 1,', &
+      '  "atoms": {', &
+      '    "elements": {', &
+      '      "number": [', &
+      '        8,', &
+      '        1', &
+      '      ]', &
+      '    },', &
+      '    "coords": {', &
+      '      "3d": [', &
+      '         1.2358341722502633E+00,', &
+      '        -9.1774253284895344E-02,', &
+      '        -6.7936144993384059E-02,', &
+      '         1.5475582000473165E+00,', &
+      '         5.7192830956765273E-01,', &
+      '         5.5691301045614838E-01', &
+      '      ]', &
+      '    },', &
+      '    "formalCharges": [ -1, 0 ]', &
+      '  }', &
+      '}'
+   rewind(unit)
+
+   call read_json(struc, unit, error)
+   close(unit, status='delete')
+   if (allocated(error)) return
+   call check(error, struc%nat, 2, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 2, "Number of species does not match")
+   if (allocated(error)) return
+   call check(error, nint(struc%charge), -1, "Total charge does not match")
+   if (allocated(error)) return
+
+end subroutine test_valid_mol2
+
+subroutine test_valid_mol3(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   character(len=*), parameter :: filename = ".test-general-qcschema-mol3.json"
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(file=filename, newunit=unit)
+   write(unit, '(a)') &
+      '{', &
+      '  "schema_version": 1,', &
+      '  "molecule": {', &
+      '    "geometry": [', &
+      '      0.0,  0.0000, -0.1294,', &
+      '      0.0, -1.4941,  1.0274,', &
+      '      0.0,  1.4941,  1.0274', &
+      '    ],', &
+      '    "symbols": ["O", "H", "H"],', &
+      '    "comment": "Water molecule"', &
+      '  }', &
+      '}'
+   rewind(unit)
+
+   call read_json(struc, unit, error)
+   close(unit, status='delete')
+   if (allocated(error)) return
+
+   call check(error, allocated(struc%comment), "Comment line should be preserved")
+   if (allocated(error)) return
+   call check(error, struc%comment, "Water molecule")
+   if (allocated(error)) return
+   call check(error, struc%nat, 3, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 2, "Number of species does not match")
+   if (allocated(error)) return
+
+end subroutine test_valid_mol3
+
+subroutine test_valid_sol1(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   character(len=*), parameter :: filename = ".test-general-pmg-sol1.json"
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(file=filename, newunit=unit)
+   write(unit, '(a)') &
+      '{', &
+      '  "@module": "pymatgen.core.structure",', &
+      '  "@class": "Structure",', &
+      '  "charge": 0.0,', &
+      '  "lattice": {', &
+      '    "matrix": [', &
+      '      [5.59003664376222, 0.0, 0.0],', &
+      '      [0.0, 8.68089159045265, 0.0],', &
+      '      [0.0, 0.0, 8.68089159045265]', &
+      '    ],', &
+      '    "pbc": [true, true, true],', &
+      '    "a": 5.59003664376222,', &
+      '    "b": 8.68089159045265,', &
+      '    "c": 8.68089159045265,', &
+      '    "alpha": 90.0,', &
+      '    "beta": 90.0,', &
+      '    "gamma": 90.0,', &
+      '    "volume": 421.253303917213', &
+      '  },', &
+      '  "properties": {},', &
+      '  "sites": [', &
+      '    {', &
+      '      "species": [{"element": "Ti", "occu": 1}],', &
+      '      "abc": [0.0, 0.0, 0.0],', &
+      '      "properties": {},', &
+      '      "label": "Ti",', &
+      '      "xyz": [0.0, 0.0, 0.0]', &
+      '    },', &
+      '    {', &
+      '      "species": [{"element": "Ti", "occu": 1}],', &
+      '      "abc": [0.5, 0.5000000000000007, 0.5000000000000007],', &
+      '      "properties": {},', &
+      '      "label": "Ti",', &
+      '      "xyz": [2.79501832188111, 4.340445795226331, 4.340445795226331]', &
+      '    },', &
+      '    {', &
+      '      "species": [{"element": "O", "occu": 1}], ', &
+      '      "abc": [0.0, 0.30530000000000074, 0.30530000000000074],', &
+      '      "properties": {},', &
+      '      "label": "O",', &
+      '      "xyz": [0.0, 2.6502762025652005, 2.6502762025652005]', &
+      '    },', &
+      '    {', &
+      '      "species": [{"element": "O", "occu": 1}], ', &
+      '      "abc": [0.0, 0.6947000000000005, 0.6947000000000005],', &
+      '      "properties": {},', &
+      '      "label": "O",', &
+      '      "xyz": [0.0, 6.03061538788746, 6.03061538788746]', &
+      '    },', &
+      '    {', &
+      '      "species": [{"element": "O", "occu": 1}], ', &
+      '      "abc": [0.5, 0.1946999999999999, 0.8053000000000002],', &
+      '      "properties": {},', &
+      '      "label": "O",', &
+      '      "xyz": [2.79501832188111, 1.69016959266113, 6.99072199779152]', &
+      '    },', &
+      '    {', &
+      '      "species": [{"element": "O", "occu": 1}], ', &
+      '      "abc": [0.5, 0.8053000000000002, 0.1946999999999999],', &
+      '      "properties": {},', &
+      '      "label": "O",', &
+      '      "xyz": [2.79501832188111, 6.99072199779152, 1.69016959266113]', &
+      '    }', &
+      '  ]', &
+      '}'
+   rewind(unit)
+
+   call read_json(struc, unit, error)
+   close(unit, status='delete')
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 6, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 2, "Number of species does not match")
+   if (allocated(error)) return
+   call check(error, allocated(struc%lattice), .true., "Lattice is not allocated")
+   if (allocated(error)) return
+
+end subroutine test_valid_sol1
+
+subroutine test_valid_sol2(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   character(len=*), parameter :: filename = ".test-general-cjson-sol2.json"
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(file=filename, newunit=unit)
+   write(unit, '(a)') &
+      '{', &
+      '  "chemical json": 0,', &
+      '  "name": "ethane",', &
+      '  "inchi": "1/C2H6/c1-2/h1-2H3",', &
+      '  "formula": "C 2 H 6",', &
+      '  "atoms": {', &
+      '    "elements": {', &
+      '      "number": [  1,   6,   1,   1,   6,   1,   1,   1 ]', &
+      '    },', &
+      '    "coords": {', &
+      '      "3d": [  1.185080, -0.003838,  0.987524,', &
+      '               0.751621, -0.022441, -0.020839,', &
+      '               1.166929,  0.833015, -0.569312,', &
+      '               1.115519, -0.932892, -0.514525,', &
+      '              -0.751587,  0.022496,  0.020891,', &
+      '              -1.166882, -0.833372,  0.568699,', &
+      '              -1.115691,  0.932608,  0.515082,', &
+      '              -1.184988,  0.004424, -0.987522 ]', &
+      '    }', &
+      '  },', &
+      '  "bonds": {', &
+      '    "connections": {', &
+      '      "index": [ 0, 1,', &
+      '                 1, 2,', &
+      '                 1, 3,', &
+      '                 1, 4,', &
+      '                 4, 5,', &
+      '                 4, 6,', &
+      '                 4, 7 ]', &
+      '    },', &
+      '    "order": [ 1, 1, 1, 1, 1, 1, 1 ]', &
+      '  },', &
+      '  "properties": {', &
+      '    "molecular mass": 30.0690,', &
+      '    "melting point": -172,', &
+      '    "boiling point": -88', &
+      '  }', &
+      '}'
+   rewind(unit)
+
+   call read_json(struc, unit, error)
+   close(unit, status='delete')
+   if (allocated(error)) return
+
+   call check(error, allocated(struc%comment), "Comment line should be preserved")
+   if (allocated(error)) return
+   call check(error, struc%comment, "ethane")
+   if (allocated(error)) return
+   call check(error, struc%nat, 8, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 2, "Number of species does not match")
+   if (allocated(error)) return
+   call check(error, struc%nbd, 7, "Number of bonds does not match")
+   if (allocated(error)) return
+
+end subroutine test_valid_sol2
+
+subroutine test_valid_sol3(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   character(len=*), parameter :: filename = ".test-general-qcsk-sol3.json"
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(file=filename, newunit=unit)
+   write(unit, '(a)') &
+      '{', &
+      '  "provenance": {', &
+      '    "creator": "mctc-lib",', &
+      '    "version": "0.4.2",', &
+      '    "routine": "mctc_io_write_qcschema::write_qcschema"', &
+      '  },', &
+      '  "comment": "TiO2 rutile",', &
+      '  "symbols": ["Ti", "Ti", "O", "O", "O", "O"],', &
+      '  "atomic_numbers": [22, 22, 8, 8, 8, 8],', &
+      '  "geometry": [', &
+      '     0.0000000000000000E+00, 0.0000000000000000E+00, 0.0000000000000000E+00,', &
+      '     5.2818191416515159E+00, 8.2022538117381334E+00, 8.2022538117381334E+00,', &
+      '     6.1333938828927657E-16, 5.0082961774473045E+00, 5.0082961774473045E+00,', &
+      '     1.3956333869785798E-15, 1.1396211446028962E+01, 1.1396211446028962E+01,', &
+      '     5.2818191416515150E+00, 3.1939576342908298E+00, 1.3210549989185438E+01,', &
+      '     5.2818191416515150E+00, 1.3210549989185438E+01, 3.1939576342908289E+00', &
+      '  ],', &
+      '  "molecular_charge": 0,', &
+      '  "extras": {', &
+      '    "periodic": {', &
+      '      "lattice": [', &
+      '         5.5900366437622173E+00, 0.0000000000000000E+00, 0.0000000000000000E+00,', &
+      '         5.3155130499965102E-16, 8.6808915904526547E+00, 0.0000000000000000E+00,', &
+      '         5.3155130499965102E-16, 5.3155130499965102E-16, 8.6808915904526547E+00', &
+      '      ]', &
+      '    }', &
+      '  }', &
+      '}'
+   rewind(unit)
+
+   call read_json(struc, unit, error)
+   close(unit, status='delete')
+   if (allocated(error)) return
+
+   call check(error, allocated(struc%comment), "Comment line should be preserved")
+   if (allocated(error)) return
+   call check(error, struc%comment, "TiO2 rutile")
+   if (allocated(error)) return
+   call check(error, struc%nat, 6, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 2, "Number of species does not match")
+   if (allocated(error)) return
+   call check(error, all(struc%periodic), .true., "Structure should be periodic")
+   if (allocated(error)) return
+
+end subroutine test_valid_sol3
+
+end module test_read_json


### PR DESCRIPTION
- all JSON formats are available with `json` extension, the `read_json` procedure dispatches to the format specific readers based on the schema information in the JSON file
- update README to list all formats supported in mctc-lib