### PR TITLE
Timer

### DIFF
--- a/src/mctc/env.f90
+++ b/src/mctc/env.f90
@@ -42,6 +42,7 @@ module mctc_env
    use mctc_env_error, only : error_type, fatal_error, mctc_stat
    use mctc_env_system, only : get_argument, get_variable, &
       & is_unix, is_windows
+   use mctc_env_timer, only : timer_type, format_time
    implicit none
    public
 

--- a/src/mctc/env/CMakeLists.txt
+++ b/src/mctc/env/CMakeLists.txt
@@ -20,6 +20,7 @@ list(
   "${dir}/error.f90"
   "${dir}/system.f90"
   "${dir}/testing.f90"
+  "${dir}/timer.f90"
 )
 
 set(srcs "${srcs}" PARENT_SCOPE)

--- a/src/mctc/env/meson.build
+++ b/src/mctc/env/meson.build
@@ -17,4 +17,5 @@ srcs += files(
   'error.f90',
   'system.f90',
   'testing.f90',
+  'timer.f90',
 )

--- a/src/mctc/env/timer.f90
+++ b/src/mctc/env/timer.f90
@@ -39,6 +39,22 @@ pure function format_string_int(val, format) result(str)
    end if
 end function format_string_int
 
+pure function format_string_real_dp(val, format) result(str)
+   real(wp), intent(in) :: val
+   character(len=*), intent(in) :: format
+   character(len=:), allocatable :: str
+
+   character(len=128) :: buffer
+   integer :: stat
+
+   write(buffer, format, iostat=stat) val
+   if (stat == 0) then
+      str = trim(buffer)
+   else
+      str = "*"
+   end if
+end function format_string_real_dp
+
 subroutine push(self, label)
    class(timer_type), intent(inout) :: self
    character(len=*), intent(in) :: label
@@ -148,21 +164,21 @@ function format_time(time) result(string)
    secs = time - mins*60.0_wp
 
    if (days > 0) then
-      string = format_string(days, '(i0, " d,")')
+      string = format_string_int(days, '(i0, " d,")')
    else
       string = repeat(" ", 4)
    end if
    if (hours > 0) then
-      string = string // format_string(hours, '(1x, i2, " h,")')
+      string = string // format_string_int(hours, '(1x, i2, " h,")')
    else
       string = string // repeat(" ", 6)
    end if
    if (mins > 0) then
-      string = string // format_string(mins, '(1x, i2, " min,")')
+      string = string // format_string_int(mins, '(1x, i2, " min,")')
    else
       string = string // repeat(" ", 8)
    end if
-   string = string // format_string(secs, '(f6.3)')//" sec"
+   string = string // format_string_real_dp(secs, '(f6.3)')//" sec"
 end function format_time
 
 

--- a/src/mctc/env/timer.f90
+++ b/src/mctc/env/timer.f90
@@ -1,3 +1,17 @@
+! This file is part of mctc-lib.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
 module mctc_env_timer
    use mctc_env_accuracy, only : wp, i8
    implicit none
@@ -22,38 +36,6 @@ module mctc_env_timer
    end type timer_type
 
 contains
-
-pure function format_string_int(val, format) result(str)
-   integer, intent(in) :: val
-   character(len=*), intent(in) :: format
-   character(len=:), allocatable :: str
-
-   character(len=128) :: buffer
-   integer :: stat
-
-   write(buffer, format, iostat=stat) val
-   if (stat == 0) then
-      str = trim(buffer)
-   else
-      str = "*"
-   end if
-end function format_string_int
-
-pure function format_string_real_dp(val, format) result(str)
-   real(wp), intent(in) :: val
-   character(len=*), intent(in) :: format
-   character(len=:), allocatable :: str
-
-   character(len=128) :: buffer
-   integer :: stat
-
-   write(buffer, format, iostat=stat) val
-   if (stat == 0) then
-      str = trim(buffer)
-   else
-      str = "*"
-   end if
-end function format_string_real_dp
 
 subroutine push(self, label)
    class(timer_type), intent(inout) :: self
@@ -224,5 +206,37 @@ pure subroutine resize(var, n)
    end if
 
 end subroutine resize
+
+pure function format_string_int(val, format) result(str)
+   integer, intent(in) :: val
+   character(len=*), intent(in) :: format
+   character(len=:), allocatable :: str
+
+   character(len=128) :: buffer
+   integer :: stat
+
+   write(buffer, format, iostat=stat) val
+   if (stat == 0) then
+      str = trim(buffer)
+   else
+      str = "*"
+   end if
+end function format_string_int
+
+pure function format_string_real_dp(val, format) result(str)
+   real(wp), intent(in) :: val
+   character(len=*), intent(in) :: format
+   character(len=:), allocatable :: str
+
+   character(len=128) :: buffer
+   integer :: stat
+
+   write(buffer, format, iostat=stat) val
+   if (stat == 0) then
+      str = trim(buffer)
+   else
+      str = "*"
+   end if
+end function format_string_real_dp
 
 end module mctc_env_timer

--- a/src/mctc/env/timer.f90
+++ b/src/mctc/env/timer.f90
@@ -1,0 +1,212 @@
+module mctc_env_timer
+   use mctc_env_accuracy, only : wp, i8
+   implicit none
+   private
+
+   public :: timer_type, format_time
+
+   type :: time_record
+      character(len=:), allocatable :: label
+      logical :: running = .false.
+      real(wp) :: time = 0.0_wp
+   end type time_record
+
+   type :: timer_type
+      integer :: n = 0
+      character(len=:), allocatable :: last
+      type(time_record), allocatable :: record(:)
+   contains
+      procedure :: push
+      procedure :: pop
+      procedure :: get
+   end type timer_type
+
+contains
+
+pure function format_string_int(val, format) result(str)
+   integer, intent(in) :: val
+   character(len=*), intent(in) :: format
+   character(len=:), allocatable :: str
+
+   character(len=128) :: buffer
+   integer :: stat
+
+   write(buffer, format, iostat=stat) val
+   if (stat == 0) then
+      str = trim(buffer)
+   else
+      str = "*"
+   end if
+end function format_string_int
+
+subroutine push(self, label)
+   class(timer_type), intent(inout) :: self
+   character(len=*), intent(in) :: label
+
+   integer :: it
+
+   if (.not.allocated(self%record)) call resize(self%record)
+   it = find(self%record(:self%n), label)
+
+   if (it == 0) then
+      if (self%n >= size(self%record)) then
+         call resize(self%record)
+      end if
+
+      self%n = self%n + 1
+      it = self%n
+      self%record(it) = time_record(label)
+   end if
+
+   associate(record => self%record(it))
+      self%last = record%label
+      record%time = record%time + timing() * merge(+1, -1, record%running)
+      record%running = .not.record%running
+   end associate
+end subroutine push
+
+
+subroutine pop(self)
+   class(timer_type), intent(inout) :: self
+
+   integer :: it
+
+   if (.not.allocated(self%record)) return
+   it = find(self%record(:self%n), self%last)
+   if (it == 0) return
+
+   associate(record => self%record(it))
+      record%time = record%time + timing() * merge(+1, -1, record%running)
+      record%running = .not.record%running
+   end associate
+   if (allocated(self%last)) deallocate(self%last)
+end subroutine pop
+
+
+function get(self, label) result(time)
+   class(timer_type), intent(in) :: self
+   character(len=*), intent(in) :: label
+   real(wp) :: time
+
+   integer :: it
+
+   time = 0.0_wp
+   if (self%n <= 0) return
+   it = find(self%record(:self%n), label)
+   if (it == 0) return
+
+   associate(record => self%record(it))
+      time = record%time
+      if (record%running) then
+         time = time + timing()
+      end if
+   end associate
+end function get
+
+
+pure function find(record, label) result(pos)
+   type(time_record), intent(in) :: record(:)
+   character(len=*), intent(in), optional :: label
+   integer :: pos
+
+   integer :: i
+
+   pos = 0
+   if (present(label)) then
+      do i = size(record), 1, -1
+         if (allocated(record(i)%label)) then
+            if (label == record(i)%label) then
+               pos = i
+               exit
+            end if
+         end if
+      end do
+   else
+      do i = size(record), 1, -1
+         if (record(i)%running) then
+            pos = i
+            exit
+         end if
+      end do
+   end if
+end function find
+
+
+function format_time(time) result(string)
+   real(wp), intent(in) :: time
+   character(len=:), allocatable :: string
+
+   real(wp) :: secs
+   integer :: mins, hours, days
+
+   secs = time
+   days = int(secs/86400.0_wp)
+   secs = secs - days*86400.0_wp
+   hours = int(secs/3600.0_wp)
+   secs = secs - hours*3600.0_wp
+   mins = int(secs/60.0_wp)
+   secs = time - mins*60.0_wp
+
+   if (days > 0) then
+      string = format_string(days, '(i0, " d,")')
+   else
+      string = repeat(" ", 4)
+   end if
+   if (hours > 0) then
+      string = string // format_string(hours, '(1x, i2, " h,")')
+   else
+      string = string // repeat(" ", 6)
+   end if
+   if (mins > 0) then
+      string = string // format_string(mins, '(1x, i2, " min,")')
+   else
+      string = string // repeat(" ", 8)
+   end if
+   string = string // format_string(secs, '(f6.3)')//" sec"
+end function format_time
+
+
+function timing() result(time)
+   real(wp) :: time
+
+   integer(i8) :: time_count, time_rate, time_max
+   call system_clock(time_count, time_rate, time_max)
+   time = real(time_count, wp)/real(time_rate, wp)
+end function timing
+
+
+!> Reallocate list of timing records
+pure subroutine resize(var, n)
+   !> Instance of the array to be resized
+   type(time_record), allocatable, intent(inout) :: var(:)
+   !> Dimension of the final array size
+   integer, intent(in), optional :: n
+
+   type(time_record), allocatable :: tmp(:)
+   integer :: this_size, new_size
+   integer, parameter :: initial_size = 20
+
+   if (allocated(var)) then
+      this_size = size(var, 1)
+      call move_alloc(var, tmp)
+   else
+      this_size = initial_size
+   end if
+
+   if (present(n)) then
+      new_size = n
+   else
+      new_size = this_size + this_size/2 + 1
+   end if
+
+   allocate(var(new_size))
+
+   if (allocated(tmp)) then
+      this_size = min(size(tmp, 1), size(var, 1))
+      var(:this_size) = tmp(:this_size)
+      deallocate(tmp)
+   end if
+
+end subroutine resize
+
+end module mctc_env_timer

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,7 @@ set(
   "write-turbomole"
   "write-vasp"
   "write-xyz"
+  "timer"
 )
 set(
   test-srcs

--- a/test/main.f90
+++ b/test/main.f90
@@ -22,6 +22,7 @@ program tester
    use test_data, only : collect_data
    use test_math, only : collect_math
    use test_ncoord, only : collect_ncoord
+   use test_timer, only : collect_timer
    use test_read, only : collect_read
    use test_read_aims, only : collect_read_aims
    use test_read_cjson, only : collect_read_cjson
@@ -63,6 +64,7 @@ program tester
       & new_testsuite("data", collect_data), &
       & new_testsuite("math", collect_math), &
       & new_testsuite("ncoord", collect_ncoord), &
+      & new_testsuite("timer", collect_timer), &
       & new_testsuite("symbols", collect_symbols), &
       & new_testsuite("read", collect_read), &
       & new_testsuite("read-aims", collect_read_aims), &

--- a/test/meson.build
+++ b/test/meson.build
@@ -45,6 +45,7 @@ tests = [
   'write-turbomole',
   'write-vasp',
   'write-xyz',
+  'timer',
 ]
 
 test_srcs = files(

--- a/test/test_timer.f90
+++ b/test/test_timer.f90
@@ -61,17 +61,11 @@ subroutine test_push_pop(error)
    call tmr%push("test")
 
    ! busy-wait for a small positive time interval
-   call system_clock(t0, rate)
-   do
-      call system_clock(tnow)
-      if (real(tnow - t0, wp)/real(rate, wp) >= 1.0e-3_wp) exit
-   end do
-
-   call tmr%pop()
+   call sleep(1)
 
    elapsed = tmr%get("test")
 
-   call check(error, elapsed > 0.0_wp, .true., "timer elapsed time must be positive")
+   call check(error, elapsed > 1.0_wp, .true., "timer elapsed time must be positive")
 
 end subroutine test_push_pop
 

--- a/test/test_timer.f90
+++ b/test/test_timer.f90
@@ -1,0 +1,78 @@
+! This file is part of mctc-lib.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+module test_timer
+   use mctc_env_accuracy, only : wp
+   use mctc_env_testing, only : new_unittest, unittest_type, error_type, check
+   use mctc_env_timer
+   implicit none
+   private
+
+   public :: collect_timer
+
+contains
+
+subroutine collect_timer(testsuite)
+
+   type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+   testsuite = [ &
+      & new_unittest("format-time", test_format_time), &
+      & new_unittest("push-pop-get", test_push_pop) &
+      & ]
+
+end subroutine collect_timer
+
+
+subroutine test_format_time(error)
+
+   type(error_type), allocatable, intent(out) :: error
+   character(len=:), allocatable :: s, expected
+   real(wp) :: t
+
+   t = 1.234_wp
+   s = format_time(t)
+   expected = repeat(' ', 19) // "1.234 sec"
+
+   call check(error, s, expected)
+
+end subroutine test_format_time
+
+
+subroutine test_push_pop(error)
+
+   type(error_type), allocatable, intent(out) :: error
+   type(timer_type) :: tmr
+   real(wp) :: elapsed
+   integer :: t0, tnow, rate
+
+   ! start the timer record
+   call tmr%push("test")
+
+   ! busy-wait for a small positive time interval
+   call system_clock(t0, rate)
+   do
+      call system_clock(tnow)
+      if (real(tnow - t0, wp)/real(rate, wp) >= 1.0e-3_wp) exit
+   end do
+
+   call tmr%pop()
+
+   elapsed = tmr%get("test")
+
+   call check(error, elapsed > 0.0_wp, .true., "timer elapsed time must be positive")
+
+end subroutine test_push_pop
+
+end module test_timer


### PR DESCRIPTION
Add a lightweight timing utility module, a copy of the tblite timer (https://github.com/tblite/tblite.git),  mctc_env_timer providing timer_type (with push, pop, get) and format_time for readable elapsed-time reporting. Include unit tests exercising formatting and basic push/pop/get behavior.

**Motivation:**
Provide consistent, reusable timing support for measuring and formatting elapsed times across the codebase and to aid profiling in tests and applications.

**Build and run tests with fpm:**
fpm build
frm test

**Build and run tests with cmake**
cmake -B _build -G Ninja
cmake --build _build
pushd _build && ctest && popd

**Build and run tests with Meson:**
meson setup _build
meson compile -C _build
meson test -C _build --print-errorlogs

**Run only the timer tests:**
meson test -C _build test_timer --print-errorlogs

**Notes:**

- format_time returns a fixed-width, string (days/hours/minutes/seconds): X d X h X min X.XXX sec.
- timer_type%push toggles start for a named timer
- timer_type%pop toggles stop for a timer
- timer_type%get returns accumulated time including any currently running interval

The API is backwards-compatible and uses existing kind definitions from mctc_env_accuracy.