### PR TITLE
add fractional site occupancy for pdb files

### DIFF
--- a/doc/format-pdb.md
+++ b/doc/format-pdb.md
@@ -19,6 +19,8 @@ title: Protein Data Bank (PDB) Format
 The Protein Data Bank (PDB) format is a standard for representing macromolecular structures.
 This implementation reads atomic coordinates from ATOM and HETATM records and bond connectivity from CONECT records.
 Alternative locations are resolved by keeping, for each atomic site, the conformer with the highest occupancy.
+Duplicated partial-occupancy sites are accepted only when at least one record uses an alternative-location indicator.
+When writing PDB, occupancy values are taken from PDB atom annotations if they are present.
 
 ### Supported Record Types
 

--- a/doc/format-pdb.md
+++ b/doc/format-pdb.md
@@ -18,6 +18,7 @@ title: Protein Data Bank (PDB) Format
 
 The Protein Data Bank (PDB) format is a standard for representing macromolecular structures.
 This implementation reads atomic coordinates from ATOM and HETATM records and bond connectivity from CONECT records.
+Alternative locations are resolved by keeping, for each atomic site, the conformer with the highest occupancy.
 
 ### Supported Record Types
 
@@ -180,7 +181,6 @@ END
 The following features are currently not supported:
 
 - Multiple model/file PDB input (only first model is read)
-- Fractional site occupancy (all alternative locations are treated as full atoms)
 - Cell information (CRYST1 record) is not preserved; PDB input is always handled as molecular
 - Anisotropic displacement parameters (ANISOU records)
 

--- a/doc/format-pdb.md
+++ b/doc/format-pdb.md
@@ -18,9 +18,18 @@ title: Protein Data Bank (PDB) Format
 
 The Protein Data Bank (PDB) format is a standard for representing macromolecular structures.
 This implementation reads atomic coordinates from ATOM and HETATM records and bond connectivity from CONECT records.
-Alternative locations are resolved by keeping, for each atomic site, the conformer with the highest occupancy.
-Duplicated partial-occupancy sites are accepted only when at least one record uses an alternative-location indicator.
-When writing PDB, occupancy values are taken from PDB atom annotations if they are present.
+Alternative conformations are resolved per residue. The mean occupancy of the atoms carrying
+each alternative-location identifier is used to select one conformer, without favoring a
+conformer merely because it contains more atoms. If occupancies tie, the first identifier in
+the input is selected. Atoms with a blank alternative-location identifier are shared by all
+conformations and are retained.
+
+Alternate residue identities at the same chain, sequence number, and insertion code are treated
+as conformers of one residue. If a fractionally occupied atom name is repeated at one residue
+position, every copy must have a unique, nonblank alternative-location identifier, as required
+by the PDB format. A fractional occupancy without a repeated atom site is valid and is retained.
+
+Occupancies are preserved in the PDB atom annotations and used when writing PDB output.
 
 ### Supported Record Types
 

--- a/src/mctc/io/read/pdb.f90
+++ b/src/mctc/io/read/pdb.f90
@@ -14,7 +14,7 @@
 
 module mctc_io_read_pdb
    use mctc_env_accuracy, only : wp
-   use mctc_env_error, only : error_type
+   use mctc_env_error, only : error_type, fatal_error
    use mctc_io_convert, only : aatoau
    use mctc_io_resize, only : resize
    use mctc_io_symbols, only : to_number, symbol_length
@@ -137,7 +137,13 @@ subroutine read_pdb(self, unit, error)
                & line, token, filename(unit), lnum, "unexpected value")
             return
          end if
+         if (occ < 0.0_wp .or. occ > 1.0_wp) then
+            call io_error(error, "Invalid occupancy in record", &
+               & line, token_type(55, 60), filename(unit), lnum, "expected value in [0.0, 1.0]")
+            return
+         end if
          occ_values(iatom) = occ
+         pdb(iatom)%occupancy = occ
 
          xyz(:,iatom) = coords * aatoau
          atom_type = to_number(sym(iatom))
@@ -162,6 +168,9 @@ subroutine read_pdb(self, unit, error)
       end if
    end do
 
+   call validate_partial_occupancy_sites(pdb(:iatom), occ_values(:iatom), error)
+   if (allocated(error)) return
+
    allocate(keep(iatom), source=.true.)
    call drop_low_occupancy_alternatives(pdb(:iatom), occ_values(:iatom), keep)
 
@@ -179,6 +188,56 @@ subroutine read_pdb(self, unit, error)
    self%charge = sum(pdb(map)%charge)
 
 end subroutine read_pdb
+
+
+subroutine validate_partial_occupancy_sites(pdb, occ_values, error)
+
+   type(pdb_data), intent(in) :: pdb(:)
+   real(wp), intent(in) :: occ_values(:)
+   type(error_type), allocatable, intent(out) :: error
+
+   real(wp), parameter :: occ_thr = 10 * epsilon(1.0_wp)
+
+   integer :: iatom, jatom
+   logical :: has_alternative, has_duplicate
+
+   do iatom = 1, size(pdb)
+      if (occ_values(iatom) >= 1.0_wp - occ_thr) cycle
+
+      has_alternative = .false.
+      has_duplicate = .false.
+      do jatom = 1, size(pdb)
+         if (iatom == jatom) cycle
+         if (.not.is_same_site(pdb(iatom), pdb(jatom))) cycle
+         has_duplicate = .true.
+         if (is_alternative_site(pdb(iatom), pdb(jatom))) then
+            has_alternative = .true.
+         end if
+      end do
+
+      if (has_duplicate .and. .not.has_alternative) then
+         call fatal_error(error, "Partial occupancy requires alternative location records")
+         return
+      end if
+   end do
+
+end subroutine validate_partial_occupancy_sites
+
+
+pure logical function is_same_site(lhs, rhs)
+
+   type(pdb_data), intent(in) :: lhs
+   type(pdb_data), intent(in) :: rhs
+
+   is_same_site = lhs%name == rhs%name .and. &
+      & lhs%residue == rhs%residue .and. &
+      & lhs%chains == rhs%chains .and. &
+      & lhs%residue_number == rhs%residue_number .and. &
+      & lhs%code == rhs%code .and. &
+      & lhs%segid == rhs%segid .and. &
+      & (lhs%het .eqv. rhs%het)
+
+end function is_same_site
 
 
 subroutine drop_low_occupancy_alternatives(pdb, occ_values, keep)
@@ -212,13 +271,7 @@ pure logical function is_alternative_site(lhs, rhs)
    type(pdb_data), intent(in) :: lhs
    type(pdb_data), intent(in) :: rhs
 
-   is_alternative_site = lhs%name == rhs%name .and. &
-      & lhs%residue == rhs%residue .and. &
-      & lhs%chains == rhs%chains .and. &
-      & lhs%residue_number == rhs%residue_number .and. &
-      & lhs%code == rhs%code .and. &
-      & lhs%segid == rhs%segid .and. &
-      & (lhs%het .eqv. rhs%het) .and. &
+   is_alternative_site = is_same_site(lhs, rhs) .and. &
       & (lhs%loc /= ' ' .or. rhs%loc /= ' ')
 
 end function is_alternative_site

--- a/src/mctc/io/read/pdb.f90
+++ b/src/mctc/io/read/pdb.f90
@@ -44,9 +44,12 @@ subroutine read_pdb(self, unit, error)
 
    integer, parameter :: p_initial_size = 1000 ! this is going to be a protein
 
-   integer :: iatom, jatom, iresidue, try, stat, atom_type, pos, lnum
+   integer :: iatom, jatom, iresidue, try, stat, atom_type, pos, lnum, nat
+   integer, allocatable :: map(:)
    real(wp) :: occ, temp, coords(3)
+   real(wp), allocatable :: occ_values(:)
    real(wp), allocatable :: xyz(:,:)
+   logical, allocatable :: keep(:)
    type(token_type) :: token
    character(len=4) :: a_charge
    character(len=:), allocatable :: line
@@ -55,6 +58,7 @@ subroutine read_pdb(self, unit, error)
 
    allocate(sym(p_initial_size), source=repeat(' ', symbol_length))
    allocate(xyz(3, p_initial_size), source=0.0_wp)
+   allocate(occ_values(p_initial_size), source=1.0_wp)
    allocate(pdb(p_initial_size), source=pdb_data())
 
    iatom = 0
@@ -67,6 +71,7 @@ subroutine read_pdb(self, unit, error)
       if (index(line, 'ATOM') == 1 .or. index(line, 'HETATM') == 1) then
          if (iatom >= size(xyz, 2)) call resize(xyz)
          if (iatom >= size(sym)) call resize(sym)
+         if (iatom >= size(occ_values)) call resize(occ_values)
          if (iatom >= size(pdb)) call resize(pdb)
          iatom = iatom + 1
          pdb(iatom)%het = index(line, 'HETATM') == 1
@@ -132,6 +137,7 @@ subroutine read_pdb(self, unit, error)
                & line, token, filename(unit), lnum, "unexpected value")
             return
          end if
+         occ_values(iatom) = occ
 
          xyz(:,iatom) = coords * aatoau
          atom_type = to_number(sym(iatom))
@@ -156,11 +162,88 @@ subroutine read_pdb(self, unit, error)
       end if
    end do
 
-   call new(self, sym(:iatom), xyz(:, :iatom))
-   self%pdb = pdb(:iatom)
-   self%charge = sum(pdb(:iatom)%charge)
+   allocate(keep(iatom), source=.true.)
+   call drop_low_occupancy_alternatives(pdb(:iatom), occ_values(:iatom), keep)
+
+   nat = count(keep)
+   allocate(map(nat))
+   jatom = 0
+   do iatom = 1, size(keep)
+      if (.not.keep(iatom)) cycle
+      jatom = jatom + 1
+      map(jatom) = iatom
+   end do
+
+   call new(self, sym(map), xyz(:, map))
+   self%pdb = pdb(map)
+   self%charge = sum(pdb(map)%charge)
 
 end subroutine read_pdb
+
+
+subroutine drop_low_occupancy_alternatives(pdb, occ_values, keep)
+
+   type(pdb_data), intent(in) :: pdb(:)
+   real(wp), intent(in) :: occ_values(:)
+   logical, intent(out) :: keep(:)
+
+   integer :: iatom, jatom, best
+
+   keep = .true.
+   do iatom = 1, size(pdb)
+      if (.not.keep(iatom)) cycle
+      best = iatom
+      do jatom = iatom + 1, size(pdb)
+         if (.not.is_alternative_site(pdb(iatom), pdb(jatom))) cycle
+         if (has_higher_occupancy(pdb(jatom), occ_values(jatom), pdb(best), occ_values(best))) then
+            keep(best) = .false.
+            best = jatom
+         else
+            keep(jatom) = .false.
+         end if
+      end do
+   end do
+
+end subroutine drop_low_occupancy_alternatives
+
+
+pure logical function is_alternative_site(lhs, rhs)
+
+   type(pdb_data), intent(in) :: lhs
+   type(pdb_data), intent(in) :: rhs
+
+   is_alternative_site = lhs%name == rhs%name .and. &
+      & lhs%residue == rhs%residue .and. &
+      & lhs%chains == rhs%chains .and. &
+      & lhs%residue_number == rhs%residue_number .and. &
+      & lhs%code == rhs%code .and. &
+      & lhs%segid == rhs%segid .and. &
+      & (lhs%het .eqv. rhs%het) .and. &
+      & (lhs%loc /= ' ' .or. rhs%loc /= ' ')
+
+end function is_alternative_site
+
+
+pure logical function has_higher_occupancy(candidate, candidate_occ, current, current_occ)
+
+   type(pdb_data), intent(in) :: candidate
+   real(wp), intent(in) :: candidate_occ
+   type(pdb_data), intent(in) :: current
+   real(wp), intent(in) :: current_occ
+
+   real(wp), parameter :: occ_thr = 10 * epsilon(1.0_wp)
+
+   has_higher_occupancy = .false.
+   if (candidate_occ > current_occ + occ_thr) then
+      has_higher_occupancy = .true.
+      return
+   end if
+
+   if (abs(candidate_occ - current_occ) <= occ_thr) then
+      has_higher_occupancy = candidate%loc == ' ' .and. current%loc /= ' '
+   end if
+
+end function has_higher_occupancy
 
 
 end module mctc_io_read_pdb

--- a/src/mctc/io/read/pdb.f90
+++ b/src/mctc/io/read/pdb.f90
@@ -13,6 +13,7 @@
 ! limitations under the License.
 
 module mctc_io_read_pdb
+   use, intrinsic :: ieee_arithmetic, only : ieee_is_finite
    use mctc_env_accuracy, only : wp
    use mctc_env_error, only : error_type, fatal_error
    use mctc_io_convert, only : aatoau
@@ -20,8 +21,8 @@ module mctc_io_read_pdb
    use mctc_io_symbols, only : to_number, symbol_length
    use mctc_io_structure, only : structure_type, new
    use mctc_io_structure_info, only : pdb_data, resize
-   use mctc_io_utils, only : next_line, token_type, next_token, io_error, filename, &
-      read_token, to_string
+   use mctc_io_utils, only : next_line, token_type, io_error, filename, read_token, &
+      & to_string
    implicit none
    private
 
@@ -44,10 +45,9 @@ subroutine read_pdb(self, unit, error)
 
    integer, parameter :: p_initial_size = 1000 ! this is going to be a protein
 
-   integer :: iatom, jatom, iresidue, try, stat, atom_type, pos, lnum, nat
+   integer :: iatom, jatom, try, stat, atom_type, pos, lnum, nat
    integer, allocatable :: map(:)
    real(wp) :: occ, temp, coords(3)
-   real(wp), allocatable :: occ_values(:)
    real(wp), allocatable :: xyz(:,:)
    logical, allocatable :: keep(:)
    type(token_type) :: token
@@ -58,11 +58,9 @@ subroutine read_pdb(self, unit, error)
 
    allocate(sym(p_initial_size), source=repeat(' ', symbol_length))
    allocate(xyz(3, p_initial_size), source=0.0_wp)
-   allocate(occ_values(p_initial_size), source=1.0_wp)
    allocate(pdb(p_initial_size), source=pdb_data())
 
    iatom = 0
-   iresidue = 0
 
    stat = 0
    do while(stat == 0)
@@ -71,7 +69,6 @@ subroutine read_pdb(self, unit, error)
       if (index(line, 'ATOM') == 1 .or. index(line, 'HETATM') == 1) then
          if (iatom >= size(xyz, 2)) call resize(xyz)
          if (iatom >= size(sym)) call resize(sym)
-         if (iatom >= size(occ_values)) call resize(occ_values)
          if (iatom >= size(pdb)) call resize(pdb)
          iatom = iatom + 1
          pdb(iatom)%het = index(line, 'HETATM') == 1
@@ -137,12 +134,11 @@ subroutine read_pdb(self, unit, error)
                & line, token, filename(unit), lnum, "unexpected value")
             return
          end if
-         if (occ < 0.0_wp .or. occ > 1.0_wp) then
+         if (.not.ieee_is_finite(occ) .or. occ < 0.0_wp .or. occ > 1.0_wp) then
             call io_error(error, "Invalid occupancy in record", &
                & line, token_type(55, 60), filename(unit), lnum, "expected value in [0.0, 1.0]")
             return
          end if
-         occ_values(iatom) = occ
          pdb(iatom)%occupancy = occ
 
          xyz(:,iatom) = coords * aatoau
@@ -168,11 +164,11 @@ subroutine read_pdb(self, unit, error)
       end if
    end do
 
-   call validate_partial_occupancy_sites(pdb(:iatom), occ_values(:iatom), error)
+   call validate_alternate_locations(pdb(:iatom), error)
    if (allocated(error)) return
 
    allocate(keep(iatom), source=.true.)
-   call drop_low_occupancy_alternatives(pdb(:iatom), occ_values(:iatom), keep)
+   call select_alternate_locations(pdb(:iatom), keep)
 
    nat = count(keep)
    allocate(map(nat))
@@ -190,113 +186,123 @@ subroutine read_pdb(self, unit, error)
 end subroutine read_pdb
 
 
-subroutine validate_partial_occupancy_sites(pdb, occ_values, error)
+subroutine validate_alternate_locations(pdb, error)
 
    type(pdb_data), intent(in) :: pdb(:)
-   real(wp), intent(in) :: occ_values(:)
    type(error_type), allocatable, intent(out) :: error
 
-   real(wp), parameter :: occ_thr = 10 * epsilon(1.0_wp)
+   integer :: first, last, iatom, jatom
 
-   integer :: iatom, jatom
-   logical :: has_alternative, has_duplicate
-
-   do iatom = 1, size(pdb)
-      if (occ_values(iatom) >= 1.0_wp - occ_thr) cycle
-
-      has_alternative = .false.
-      has_duplicate = .false.
-      do jatom = 1, size(pdb)
-         if (iatom == jatom) cycle
-         if (.not.is_same_site(pdb(iatom), pdb(jatom))) cycle
-         has_duplicate = .true.
-         if (is_alternative_site(pdb(iatom), pdb(jatom))) then
-            has_alternative = .true.
-         end if
+   first = 1
+   do while(first <= size(pdb))
+      last = first
+      do while(last < size(pdb))
+         if (.not.is_same_residue(pdb(first), pdb(last + 1))) exit
+         last = last + 1
       end do
 
-      if (has_duplicate .and. .not.has_alternative) then
-         call fatal_error(error, "Partial occupancy requires alternative location records")
-         return
-      end if
+      do iatom = first, last
+         do jatom = iatom + 1, last
+            if (pdb(iatom)%name /= pdb(jatom)%name) cycle
+            if (pdb(iatom)%occupancy >= 1.0_wp .and. &
+               & pdb(jatom)%occupancy >= 1.0_wp) cycle
+
+            if (pdb(iatom)%loc == " " .or. pdb(jatom)%loc == " ") then
+               call fatal_error(error, "Repeated PDB atom '"// &
+                  & trim(adjustl(pdb(iatom)%name))//"' in residue "// &
+                  & to_string(pdb(iatom)%residue_number)// &
+                  & " requires alternate location identifiers")
+               return
+            end if
+
+            if (pdb(iatom)%loc == pdb(jatom)%loc) then
+               call fatal_error(error, "Repeated PDB atom '"// &
+                  & trim(adjustl(pdb(iatom)%name))//"' in residue "// &
+                  & to_string(pdb(iatom)%residue_number)// &
+                  & " has duplicate alternate location identifier '"// &
+                  & pdb(iatom)%loc//"'")
+               return
+            end if
+         end do
+      end do
+
+      first = last + 1
    end do
 
-end subroutine validate_partial_occupancy_sites
+end subroutine validate_alternate_locations
 
 
-pure logical function is_same_site(lhs, rhs)
+pure logical function is_same_residue(lhs, rhs)
 
    type(pdb_data), intent(in) :: lhs
    type(pdb_data), intent(in) :: rhs
 
-   is_same_site = lhs%name == rhs%name .and. &
-      & lhs%residue == rhs%residue .and. &
-      & lhs%chains == rhs%chains .and. &
+   ! The residue name is intentionally omitted because alternate residue identities
+   ! occupy the same sequence position, as in PDB entry 1EN2.
+   is_same_residue = lhs%chains == rhs%chains .and. &
       & lhs%residue_number == rhs%residue_number .and. &
       & lhs%code == rhs%code .and. &
       & lhs%segid == rhs%segid .and. &
       & (lhs%het .eqv. rhs%het)
 
-end function is_same_site
+end function is_same_residue
 
 
-subroutine drop_low_occupancy_alternatives(pdb, occ_values, keep)
+subroutine select_alternate_locations(pdb, keep)
 
    type(pdb_data), intent(in) :: pdb(:)
-   real(wp), intent(in) :: occ_values(:)
    logical, intent(out) :: keep(:)
 
-   integer :: iatom, jatom, best
+   integer :: first, last, iatom, jatom, nocc
+   real(wp) :: best_occupancy, occupancy
+   character(len=1) :: best_location
+
+   real(wp), parameter :: occupancy_threshold = sqrt(epsilon(1.0_wp))
 
    keep = .true.
-   do iatom = 1, size(pdb)
-      if (.not.keep(iatom)) cycle
-      best = iatom
-      do jatom = iatom + 1, size(pdb)
-         if (.not.is_alternative_site(pdb(iatom), pdb(jatom))) cycle
-         if (has_higher_occupancy(pdb(jatom), occ_values(jatom), pdb(best), occ_values(best))) then
-            keep(best) = .false.
-            best = jatom
-         else
-            keep(jatom) = .false.
+   first = 1
+   do while(first <= size(pdb))
+      last = first
+      do while(last < size(pdb))
+         if (.not.is_same_residue(pdb(first), pdb(last + 1))) exit
+         last = last + 1
+      end do
+
+      best_location = " "
+      best_occupancy = -huge(1.0_wp)
+      do iatom = first, last
+         if (pdb(iatom)%loc == " ") cycle
+         if (any(pdb(first:iatom - 1)%loc == pdb(iatom)%loc)) cycle
+
+         ! Occupancies can vary between atoms in experimental structures. The mean
+         ! provides one score without favoring conformers containing more atoms.
+         occupancy = 0.0_wp
+         nocc = 0
+         do jatom = first, last
+            if (pdb(jatom)%loc /= pdb(iatom)%loc) cycle
+            occupancy = occupancy + pdb(jatom)%occupancy
+            nocc = nocc + 1
+         end do
+         occupancy = occupancy / real(nocc, wp)
+
+         if (occupancy > best_occupancy + occupancy_threshold) then
+            best_location = pdb(iatom)%loc
+            best_occupancy = occupancy
          end if
       end do
+
+      if (best_location /= " ") then
+         do iatom = first, last
+            if (pdb(iatom)%loc /= " " .and. pdb(iatom)%loc /= best_location) then
+               keep(iatom) = .false.
+            end if
+         end do
+      end if
+
+      first = last + 1
    end do
 
-end subroutine drop_low_occupancy_alternatives
-
-
-pure logical function is_alternative_site(lhs, rhs)
-
-   type(pdb_data), intent(in) :: lhs
-   type(pdb_data), intent(in) :: rhs
-
-   is_alternative_site = is_same_site(lhs, rhs) .and. &
-      & (lhs%loc /= ' ' .or. rhs%loc /= ' ')
-
-end function is_alternative_site
-
-
-pure logical function has_higher_occupancy(candidate, candidate_occ, current, current_occ)
-
-   type(pdb_data), intent(in) :: candidate
-   real(wp), intent(in) :: candidate_occ
-   type(pdb_data), intent(in) :: current
-   real(wp), intent(in) :: current_occ
-
-   real(wp), parameter :: occ_thr = 10 * epsilon(1.0_wp)
-
-   has_higher_occupancy = .false.
-   if (candidate_occ > current_occ + occ_thr) then
-      has_higher_occupancy = .true.
-      return
-   end if
-
-   if (abs(candidate_occ - current_occ) <= occ_thr) then
-      has_higher_occupancy = candidate%loc == ' ' .and. current%loc /= ' '
-   end if
-
-end function has_higher_occupancy
+end subroutine select_alternate_locations
 
 
 end module mctc_io_read_pdb

--- a/src/mctc/io/structure/info.f90
+++ b/src/mctc/io/structure/info.f90
@@ -36,6 +36,7 @@ module mctc_io_structure_info
       integer :: charge = 0
       integer :: residue_number = 0
       character(len=4) :: name = ' '
+      real(wp) :: occupancy = 1.0_wp
       character(len=1) :: loc = ' '
       character(len=3) :: residue = ' '
       character(len=1) :: chains = ' '

--- a/src/mctc/io/structure/info.f90
+++ b/src/mctc/io/structure/info.f90
@@ -36,7 +36,8 @@ module mctc_io_structure_info
       integer :: charge = 0
       integer :: residue_number = 0
       character(len=4) :: name = ' '
-      real(wp) :: occupancy = 1.0_wp
+      !> Fraction of structures containing this atom site
+      real(wp) :: occupancy = 1.0_wp 
       character(len=1) :: loc = ' '
       character(len=3) :: residue = ' '
       character(len=1) :: chains = ' '

--- a/src/mctc/io/write.f90
+++ b/src/mctc/io/write.f90
@@ -116,7 +116,7 @@ subroutine write_structure_to_unit(self, unit, ftype, error)
       call write_molfile(self, unit)
 
    case(filetype%pdb)
-      call write_pdb(self, unit)
+      call write_pdb(self, unit, error=error)
 
    case(filetype%pymatgen)
       call write_pymatgen(self, unit)

--- a/src/mctc/io/write/pdb.f90
+++ b/src/mctc/io/write/pdb.f90
@@ -14,6 +14,7 @@
 
 module mctc_io_write_pdb
    use mctc_env_accuracy, only : wp
+   use mctc_env_error, only : error_type, fatal_error
    use mctc_io_convert, only : autoaa
    use mctc_io_structure, only : structure_type
    implicit none
@@ -25,10 +26,11 @@ module mctc_io_write_pdb
 contains
 
 
-subroutine write_pdb(mol, unit, number)
+subroutine write_pdb(mol, unit, number, error)
    type(structure_type), intent(in) :: mol
    integer, intent(in) :: unit
    integer, intent(in), optional :: number
+   type(error_type), allocatable, intent(out), optional :: error
    character(len=6) :: w1
    character(len=4) :: sym
    character(len=2) :: a_charge
@@ -36,12 +38,23 @@ subroutine write_pdb(mol, unit, number)
    logical :: last_het
    integer :: offset, iat, jat
    real(wp) :: xyz(3)
+   type(error_type), allocatable :: local_error
    character(len=*), parameter :: pdb_format = &
       &  '(a6,i5,1x,a4,a1,a3,1x,a1,i4,a1,3x,3f8.3,2f6.2,6x,a4,a2,a2)'
 
 
    if (present(number)) write(unit, '("MODEL ",4x,i4)') number
    if (allocated(mol%pdb)) then
+      call validate_pdb_occupancy(mol, local_error)
+      if (allocated(local_error)) then
+         if (present(error)) then
+            call move_alloc(local_error, error)
+            return
+         else
+            error stop local_error%message
+         end if
+      end if
+
       offset = 0
       last_chain = mol%pdb(1)%chains
       last_het = mol%pdb(1)%het
@@ -82,7 +95,7 @@ subroutine write_pdb(mol, unit, number)
          write(unit, pdb_format) &
             &  w1, jat, mol%pdb(iat)%name, mol%pdb(iat)%loc, &
             &  mol%pdb(iat)%residue, mol%pdb(iat)%chains, mol%pdb(iat)%residue_number, &
-            &  mol%pdb(iat)%code, xyz, 1.0_wp, 0.0_wp, mol%pdb(iat)%segid, &
+            &  mol%pdb(iat)%code, xyz, mol%pdb(iat)%occupancy, 0.0_wp, mol%pdb(iat)%segid, &
             &  sym, a_charge
       enddo
    else
@@ -106,6 +119,25 @@ subroutine write_pdb(mol, unit, number)
    endif
 
 end subroutine write_pdb
+
+
+subroutine validate_pdb_occupancy(mol, error)
+
+   type(structure_type), intent(in) :: mol
+   type(error_type), allocatable, intent(out) :: error
+
+   integer :: iat
+   character(len=32) :: atom_index
+
+   do iat = 1, mol%nat
+      if (mol%pdb(iat)%occupancy < 0.0_wp .or. mol%pdb(iat)%occupancy > 1.0_wp) then
+         write(atom_index, '(i0)') iat
+         call fatal_error(error, "PDB occupancy must be in [0.0, 1.0], got invalid value at atom " // trim(atom_index))
+         return
+      end if
+   end do
+
+end subroutine validate_pdb_occupancy
 
 
 end module mctc_io_write_pdb

--- a/src/mctc/io/write/pdb.f90
+++ b/src/mctc/io/write/pdb.f90
@@ -13,10 +13,12 @@
 ! limitations under the License.
 
 module mctc_io_write_pdb
+   use, intrinsic :: ieee_arithmetic, only : ieee_is_finite
    use mctc_env_accuracy, only : wp
    use mctc_env_error, only : error_type, fatal_error
    use mctc_io_convert, only : autoaa
    use mctc_io_structure, only : structure_type
+   use mctc_io_utils, only : to_string
    implicit none
    private
 
@@ -42,8 +44,6 @@ subroutine write_pdb(mol, unit, number, error)
    character(len=*), parameter :: pdb_format = &
       &  '(a6,i5,1x,a4,a1,a3,1x,a1,i4,a1,3x,3f8.3,2f6.2,6x,a4,a2,a2)'
 
-
-   if (present(number)) write(unit, '("MODEL ",4x,i4)') number
    if (allocated(mol%pdb)) then
       call validate_pdb_occupancy(mol, local_error)
       if (allocated(local_error)) then
@@ -54,7 +54,10 @@ subroutine write_pdb(mol, unit, number, error)
             error stop local_error%message
          end if
       end if
+   end if
 
+   if (present(number)) write(unit, '("MODEL ",4x,i4)') number
+   if (allocated(mol%pdb)) then
       offset = 0
       last_chain = mol%pdb(1)%chains
       last_het = mol%pdb(1)%het
@@ -127,12 +130,12 @@ subroutine validate_pdb_occupancy(mol, error)
    type(error_type), allocatable, intent(out) :: error
 
    integer :: iat
-   character(len=32) :: atom_index
 
    do iat = 1, mol%nat
-      if (mol%pdb(iat)%occupancy < 0.0_wp .or. mol%pdb(iat)%occupancy > 1.0_wp) then
-         write(atom_index, '(i0)') iat
-         call fatal_error(error, "PDB occupancy must be in [0.0, 1.0], got invalid value at atom " // trim(atom_index))
+      if (.not.ieee_is_finite(mol%pdb(iat)%occupancy) .or. &
+         & mol%pdb(iat)%occupancy < 0.0_wp .or. mol%pdb(iat)%occupancy > 1.0_wp) then
+         call fatal_error(error, "PDB occupancy must be in [0.0, 1.0], got "// &
+            & "invalid value at atom "//to_string(iat))
          return
       end if
    end do

--- a/test/test_read_pdb.f90
+++ b/test/test_read_pdb.f90
@@ -41,9 +41,13 @@ subroutine collect_read_pdb(testsuite)
       & new_unittest("valid5-pdb", test_valid5_pdb), &
       & new_unittest("valid6-pdb", test_valid6_pdb), &
       & new_unittest("valid7-pdb", test_valid7_pdb), &
+      & new_unittest("valid8-pdb", test_valid8_pdb), &
+      & new_unittest("valid9-pdb", test_valid9_pdb), &
       & new_unittest("invalid1-pdb", test_invalid1_pdb, should_fail=.true.), &
       & new_unittest("invalid2-pdb", test_invalid2_pdb, should_fail=.true.), &
-      & new_unittest("invalid3-pdb", test_invalid3_pdb, should_fail=.true.) &
+      & new_unittest("invalid3-pdb", test_invalid3_pdb, should_fail=.true.), &
+      & new_unittest("invalid4-pdb", test_invalid4_pdb, should_fail=.true.), &
+      & new_unittest("invalid5-pdb", test_invalid5_pdb, should_fail=.true.) &
       & ]
 
 end subroutine collect_read_pdb
@@ -433,6 +437,68 @@ subroutine test_valid7_pdb(error)
 end subroutine test_valid7_pdb
 
 
+subroutine test_valid8_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM      1  N   SER A   1       0.000   0.000   0.000  1.00 10.00           N", &
+      "ATOM      2  CA ASER A   1       1.000   0.000   0.000  0.40 10.00           C", &
+      "ATOM      3  CA BSER A   1       2.000   0.000   0.000  0.60 10.00           C", &
+      "ATOM      4  C   SER A   1       3.000   0.000   0.000  1.00 10.00           C", &
+      "ATOM      5  O   SER A   1       4.000   0.000   0.000  1.00 10.00           O", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 4, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%xyz(1, 2), 2.0_wp*aatoau, thr=1.0e-12_wp, &
+      & message="Higher occupancy alternate location was not selected")
+   if (allocated(error)) return
+
+end subroutine test_valid8_pdb
+
+
+subroutine test_valid9_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM      1  N   SER A   1       0.000   0.000   0.000  1.00 10.00           N", &
+      "ATOM      2  CA BSER A   1       1.000   0.000   0.000  0.50 10.00           C", &
+      "ATOM      3  CA  SER A   1       2.000   0.000   0.000  0.50 10.00           C", &
+      "ATOM      4  C   SER A   1       3.000   0.000   0.000  1.00 10.00           C", &
+      "ATOM      5  O   SER A   1       4.000   0.000   0.000  1.00 10.00           O", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 4, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%xyz(1, 2), 2.0_wp*aatoau, thr=1.0e-12_wp, &
+      & message="Primary location should win tie against alternate location")
+   if (allocated(error)) return
+
+end subroutine test_valid9_pdb
+
+
 subroutine test_invalid1_pdb(error)
 
    !> Error handling
@@ -654,6 +720,49 @@ subroutine test_invalid3_pdb(error)
    close(unit)
 
 end subroutine test_invalid3_pdb
+
+
+subroutine test_invalid4_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM      1  N   SER A   1       0.000   0.000   0.000  1.00 10.00           N", &
+      "ATOM      2  CA  SER A   1       1.000   0.000   0.000  0.50 10.00           C", &
+      "ATOM      3  CA  SER A   1       2.000   0.000   0.000  0.50 10.00           C", &
+      "ATOM      4  C   SER A   1       3.000   0.000   0.000  1.00 10.00           C", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid4_pdb
+
+
+subroutine test_invalid5_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM      1  N   SER A   1       0.000   0.000   0.000 -0.10 10.00           N", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid5_pdb
 
 
 end module test_read_pdb

--- a/test/test_read_pdb.f90
+++ b/test/test_read_pdb.f90
@@ -39,6 +39,8 @@ subroutine collect_read_pdb(testsuite)
       & new_unittest("valid3-pdb", test_valid3_pdb), &
       & new_unittest("valid4-pdb", test_valid4_pdb), &
       & new_unittest("valid5-pdb", test_valid5_pdb), &
+      & new_unittest("valid6-pdb", test_valid6_pdb), &
+      & new_unittest("valid7-pdb", test_valid7_pdb), &
       & new_unittest("invalid1-pdb", test_invalid1_pdb, should_fail=.true.), &
       & new_unittest("invalid2-pdb", test_invalid2_pdb, should_fail=.true.), &
       & new_unittest("invalid3-pdb", test_invalid3_pdb, should_fail=.true.) &
@@ -365,6 +367,70 @@ subroutine test_valid5_pdb(error)
    if (allocated(error)) return
 
 end subroutine test_valid5_pdb
+
+
+subroutine test_valid6_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM      1  N   SER A   1       0.000   0.000   0.000  1.00 10.00           N", &
+      "ATOM      2  CA ASER A   1       1.000   0.000   0.000  0.50 10.00           C", &
+      "ATOM      3  CA BSER A   1       2.000   0.000   0.000  0.50 10.00           C", &
+      "ATOM      4  C   SER A   1       3.000   0.000   0.000  1.00 10.00           C", &
+      "ATOM      5  O   SER A   1       4.000   0.000   0.000  1.00 10.00           O", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 4, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%xyz(1, 2), 1.0_wp*aatoau, thr=1.0e-12_wp, &
+      & message="Tie occupancy should keep the first alternate location")
+   if (allocated(error)) return
+
+end subroutine test_valid6_pdb
+
+
+subroutine test_valid7_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM      1  N   SER A   1       0.000   0.000   0.000  1.00 10.00           N", &
+      "ATOM      2  CA ASER A   1       1.000   0.000   0.000  0.25 10.00           C", &
+      "ATOM      3  CA BSER A   1       2.000   0.000   0.000  0.25 10.00           C", &
+      "ATOM      4  CA CSER A   1       3.000   0.000   0.000  0.25 10.00           C", &
+      "ATOM      5  CA DSER A   1       4.000   0.000   0.000  0.25 10.00           C", &
+      "ATOM      6  C   SER A   1       5.000   0.000   0.000  1.00 10.00           C", &
+      "ATOM      7  O   SER A   1       6.000   0.000   0.000  1.00 10.00           O", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 4, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%xyz(1, 2), 1.0_wp*aatoau, thr=1.0e-12_wp, &
+      & message="Four-way tie should keep the first alternate location")
+   if (allocated(error)) return
+
+end subroutine test_valid7_pdb
 
 
 subroutine test_invalid1_pdb(error)

--- a/test/test_read_pdb.f90
+++ b/test/test_read_pdb.f90
@@ -15,6 +15,7 @@
 module test_read_pdb
    use mctc_env_accuracy, only : wp
    use mctc_env_testing, only : new_unittest, unittest_type, error_type, check
+   use mctc_io_convert, only : aatoau
    use mctc_io_read_pdb
    use mctc_io_structure, only : structure_type
    implicit none
@@ -37,6 +38,7 @@ subroutine collect_read_pdb(testsuite)
       & new_unittest("valid2-pdb", test_valid2_pdb), &
       & new_unittest("valid3-pdb", test_valid3_pdb), &
       & new_unittest("valid4-pdb", test_valid4_pdb), &
+      & new_unittest("valid5-pdb", test_valid5_pdb), &
       & new_unittest("invalid1-pdb", test_invalid1_pdb, should_fail=.true.), &
       & new_unittest("invalid2-pdb", test_invalid2_pdb, should_fail=.true.), &
       & new_unittest("invalid3-pdb", test_invalid3_pdb, should_fail=.true.) &
@@ -332,6 +334,37 @@ subroutine test_valid4_pdb(error)
    if (allocated(error)) return
 
 end subroutine test_valid4_pdb
+
+
+subroutine test_valid5_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM      1  N   SER A   1       0.000   0.000   0.000  1.00 10.00           N", &
+      "ATOM      2  CA ASER A   1       1.000   0.000   0.000  0.60 10.00           C", &
+      "ATOM      3  CA BSER A   1       2.000   0.000   0.000  0.40 10.00           C", &
+      "ATOM      4  C   SER A   1       3.000   0.000   0.000  1.00 10.00           C", &
+      "ATOM      5  O   SER A   1       4.000   0.000   0.000  1.00 10.00           O", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 4, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%xyz(1, 2), 1.0_wp*aatoau, thr=1.0e-12_wp, &
+      & message="Highest occupancy alternate location was not selected")
+   if (allocated(error)) return
+
+end subroutine test_valid5_pdb
 
 
 subroutine test_invalid1_pdb(error)

--- a/test/test_read_pdb.f90
+++ b/test/test_read_pdb.f90
@@ -16,7 +16,7 @@ module test_read_pdb
    use mctc_env_accuracy, only : wp
    use mctc_env_testing, only : new_unittest, unittest_type, error_type, check
    use mctc_io_convert, only : aatoau
-   use mctc_io_read_pdb
+   use mctc_io_read_pdb, only : read_pdb
    use mctc_io_structure, only : structure_type
    implicit none
    private
@@ -43,11 +43,17 @@ subroutine collect_read_pdb(testsuite)
       & new_unittest("valid7-pdb", test_valid7_pdb), &
       & new_unittest("valid8-pdb", test_valid8_pdb), &
       & new_unittest("valid9-pdb", test_valid9_pdb), &
+      & new_unittest("valid10-pdb", test_valid10_pdb), &
+      & new_unittest("valid11-pdb", test_valid11_pdb), &
       & new_unittest("invalid1-pdb", test_invalid1_pdb, should_fail=.true.), &
       & new_unittest("invalid2-pdb", test_invalid2_pdb, should_fail=.true.), &
       & new_unittest("invalid3-pdb", test_invalid3_pdb, should_fail=.true.), &
       & new_unittest("invalid4-pdb", test_invalid4_pdb, should_fail=.true.), &
-      & new_unittest("invalid5-pdb", test_invalid5_pdb, should_fail=.true.) &
+      & new_unittest("invalid5-pdb", test_invalid5_pdb, should_fail=.true.), &
+      & new_unittest("invalid6-pdb", test_invalid6_pdb, should_fail=.true.), &
+      & new_unittest("invalid7-pdb", test_invalid7_pdb, should_fail=.true.), &
+      & new_unittest("invalid8-pdb", test_invalid8_pdb, should_fail=.true.), &
+      & new_unittest("invalid9-pdb", test_invalid9_pdb, should_fail=.true.) &
       & ]
 
 end subroutine collect_read_pdb
@@ -152,6 +158,9 @@ subroutine test_valid1_pdb(error)
    call check(error, struc%nid, 4, "Number of species does not match")
    if (allocated(error)) return
    call check(error, struc%charge, 0.0_wp, "Total charge is not correct")
+   if (allocated(error)) return
+   call check(error, struc%pdb(74)%occupancy, 0.91_wp, &
+      & "Unique partial occupancy was not preserved")
    if (allocated(error)) return
 
 end subroutine test_valid1_pdb
@@ -479,10 +488,11 @@ subroutine test_valid9_pdb(error)
    open(status='scratch', newunit=unit)
    write(unit, '(a)') &
       "ATOM      1  N   SER A   1       0.000   0.000   0.000  1.00 10.00           N", &
-      "ATOM      2  CA BSER A   1       1.000   0.000   0.000  0.50 10.00           C", &
-      "ATOM      3  CA  SER A   1       2.000   0.000   0.000  0.50 10.00           C", &
+      "ATOM      2  CA ASER A   1       1.000   0.000   0.000  0.50 10.00           C", &
+      "ATOM      3  CA BSER A   1       2.000   0.000   0.000  0.50 10.00           C", &
       "ATOM      4  C   SER A   1       3.000   0.000   0.000  1.00 10.00           C", &
-      "ATOM      5  O   SER A   1       4.000   0.000   0.000  1.00 10.00           O", &
+      "ATOM      5  O  BSER A   1       4.000   0.000   0.000  0.50 10.00           O", &
+      "ATOM      6  O  ASER A   1       5.000   0.000   0.000  0.50 10.00           O", &
       "END"
    rewind(unit)
 
@@ -492,11 +502,94 @@ subroutine test_valid9_pdb(error)
 
    call check(error, struc%nat, 4, "Number of atoms does not match")
    if (allocated(error)) return
-   call check(error, struc%xyz(1, 2), 2.0_wp*aatoau, thr=1.0e-12_wp, &
-      & message="Primary location should win tie against alternate location")
+   call check(error, struc%pdb(2)%loc, "A", &
+      & "Tie did not retain the first alternate conformation")
+   if (allocated(error)) return
+   call check(error, struc%pdb(4)%loc, "A", &
+      & "Atoms from different alternate conformations were mixed")
    if (allocated(error)) return
 
 end subroutine test_valid9_pdb
+
+
+subroutine test_valid10_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   ! Atomic coordinates are taken from the GLU 4 alternate conformations in 1A6M.
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM     26  CB AGLU A   4      -0.240  13.427  24.764  0.57 12.43           C  ", &
+      "ATOM     27  CB BGLU A   4      -0.348  13.314  24.713  0.43 12.28           C  ", &
+      "ATOM     28  CG AGLU A   4      -0.998  14.701  25.049  0.57 13.70           C  ", &
+      "ATOM     29  CG BGLU A   4       0.722  13.364  25.766  0.43 12.57           C  ", &
+      "ATOM     30  CD AGLU A   4      -0.235  16.019  25.130  0.57 12.95           C  ", &
+      "ATOM     31  CD BGLU A   4       1.620  14.595  25.723  0.43 12.08           C  ", &
+      "ATOM     32  OE1AGLU A   4       0.997  15.968  25.169  0.57 16.22           O  ", &
+      "ATOM     33  OE1BGLU A   4       1.176  15.696  25.424  0.43 11.14           O  ", &
+      "ATOM     34  OE2AGLU A   4      -0.894  17.080  25.119  0.57 12.43           O  ", &
+      "ATOM     35  OE2BGLU A   4       2.821  14.287  25.928  0.43 12.02           O  ", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 5, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, all(struc%pdb%loc == "A"), .true., &
+      & "Highest-occupancy 1A6M conformation was not selected")
+   if (allocated(error)) return
+   call check(error, struc%pdb(1)%occupancy, 0.57_wp, &
+      & "Selected PDB occupancy was not preserved")
+   if (allocated(error)) return
+
+end subroutine test_valid10_pdb
+
+
+subroutine test_valid11_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   ! Residue 10 in 1EN2 contains alternate SER and GLY identities.
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM     57  N  ASER A  10      -6.973   7.149  19.576  0.33 23.87           N  ", &
+      "ATOM     58  CA ASER A  10      -6.498   5.882  20.072  0.33 23.51           C  ", &
+      "ATOM     59  C  ASER A  10      -5.157   5.939  20.783  0.33 20.73           C  ", &
+      "ATOM     60  O  ASER A  10      -4.407   6.920  20.735  0.33 18.63           O  ", &
+      "ATOM     61  CB ASER A  10      -6.423   4.843  18.935  0.33 25.06           C  ", &
+      "ATOM     62  OG ASER A  10      -5.085   4.685  18.488  0.33 26.99           O  ", &
+      "ATOM     63  N  BGLY A  10      -6.973   7.149  19.576  0.67 23.87           N  ", &
+      "ATOM     64  CA BGLY A  10      -6.498   5.882  20.072  0.67 23.51           C  ", &
+      "ATOM     65  C  BGLY A  10      -5.157   5.939  20.783  0.67 20.73           C  ", &
+      "ATOM     66  O  BGLY A  10      -4.407   6.920  20.735  0.67 18.63           O  ", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 4, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, all(struc%pdb%loc == "B"), .true., &
+      & "Highest-occupancy 1EN2 residue identity was not selected")
+   if (allocated(error)) return
+   call check(error, struc%pdb(1)%residue, "GLY", &
+      & "Incorrect 1EN2 residue identity was selected")
+   if (allocated(error)) return
+
+end subroutine test_valid11_pdb
 
 
 subroutine test_invalid1_pdb(error)
@@ -763,6 +856,94 @@ subroutine test_invalid5_pdb(error)
    close(unit)
 
 end subroutine test_invalid5_pdb
+
+
+subroutine test_invalid6_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   ! one alternative CA has blank alternative location, while the other uses B
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM      1  N   SER A   1       0.000   0.000   0.000  1.00 10.00           N", &
+      "ATOM      2  CA  SER A   1       1.000   0.000   0.000  0.40 10.00           C", &
+      "ATOM      3  CA BSER A   1       2.000   0.000   0.000  0.60 10.00           C", &
+      "ATOM      4  C   SER A   1       3.000   0.000   0.000  1.00 10.00           C", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid6_pdb
+
+
+subroutine test_invalid7_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   ! both alternative CA positions use identifer A
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM      1  CA ASER A   1       1.000   0.000   0.000  0.50 10.00           C", &
+      "ATOM      2  CA ASER A   1       2.000   0.000   0.000  0.50 10.00           C", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid7_pdb
+
+
+subroutine test_invalid8_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   ! occupancy is greater than 1, which is unphysical
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM      1  N   SER A   1       0.000   0.000   0.000  1.10 10.00           N", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid8_pdb
+
+
+subroutine test_invalid9_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   ! occupancy is NaN
+   open(status='scratch', newunit=unit)
+   write(unit, '(a)') &
+      "ATOM      1  N   SER A   1       0.000   0.000   0.000   NaN 10.00           N", &
+      "END"
+   rewind(unit)
+
+   call read_pdb(struc, unit, error)
+   close(unit)
+
+end subroutine test_invalid9_pdb
 
 
 end module test_read_pdb

--- a/test/test_write_pdb.f90
+++ b/test/test_write_pdb.f90
@@ -13,6 +13,7 @@
 ! limitations under the License.
 
 module test_write_pdb
+   use mctc_env_accuracy, only : wp
    use mctc_env_testing, only : new_unittest, unittest_type, error_type, check
    use testsuite_structure, only : get_structure
    use mctc_io_write_pdb
@@ -34,7 +35,10 @@ subroutine collect_write_pdb(testsuite)
    type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
    testsuite = [ &
-      & new_unittest("valid1-pdb", test_valid1_pdb) &
+      & new_unittest("valid1-pdb", test_valid1_pdb), &
+      & new_unittest("valid2-pdb", test_valid2_pdb), &
+      & new_unittest("invalid1-pdb", test_invalid1_pdb, should_fail=.true.), &
+      & new_unittest("invalid2-pdb", test_invalid2_pdb, should_fail=.true.) &
       & ]
 
 end subroutine collect_write_pdb
@@ -66,6 +70,113 @@ subroutine test_valid1_pdb(error)
    if (allocated(error)) return
 
 end subroutine test_valid1_pdb
+
+
+subroutine test_valid2_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+   real(wp) :: xyz(3, 3)
+   character(len=120) :: line
+
+   xyz(:, 1) = [0.0_wp, 0.0_wp, 0.0_wp]
+   xyz(:, 2) = [1.0_wp, 0.0_wp, 0.0_wp]
+   xyz(:, 3) = [2.0_wp, 0.0_wp, 0.0_wp]
+
+   call new(struc, [character(len=2) :: "N ", "C ", "C "], xyz)
+   allocate(struc%pdb(struc%nat))
+
+   struc%pdb(:)%residue = "SER"
+   struc%pdb(:)%chains = "A"
+   struc%pdb(:)%residue_number = 1
+
+   struc%pdb(1)%name = " N  "
+   struc%pdb(1)%occupancy = 1.00_wp
+
+   struc%pdb(2)%name = " CA "
+   struc%pdb(2)%loc = "A"
+   struc%pdb(2)%occupancy = 0.60_wp
+
+   struc%pdb(3)%name = " CA "
+   struc%pdb(3)%loc = "B"
+   struc%pdb(3)%occupancy = 0.40_wp
+
+   open(status='scratch', newunit=unit)
+   call write_pdb(struc, unit)
+   rewind(unit)
+
+   read(unit, '(a)') line
+   read(unit, '(a)') line
+   call check(error, line(17:17), "A", "Alternative location indicator was not written")
+   if (allocated(error)) return
+   call check(error, line(55:60), "  0.60", "Partial occupancy for conformer A was not written")
+   if (allocated(error)) return
+
+   read(unit, '(a)') line
+   call check(error, line(17:17), "B", "Alternative location indicator was not written")
+   if (allocated(error)) return
+   call check(error, line(55:60), "  0.40", "Partial occupancy for conformer B was not written")
+   if (allocated(error)) return
+
+   close(unit)
+
+end subroutine test_valid2_pdb
+
+
+subroutine test_invalid1_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+   real(wp) :: xyz(3, 1)
+
+   xyz(:, 1) = [0.0_wp, 0.0_wp, 0.0_wp]
+
+   call new(struc, [character(len=2) :: "C "], xyz)
+   allocate(struc%pdb(struc%nat))
+
+   struc%pdb(1)%name = " C  "
+   struc%pdb(1)%residue = "SER"
+   struc%pdb(1)%chains = "A"
+   struc%pdb(1)%residue_number = 1
+   struc%pdb(1)%occupancy = 1.50_wp
+
+   open(status='scratch', newunit=unit)
+   call write_pdb(struc, unit, error=error)
+   close(unit)
+
+end subroutine test_invalid1_pdb
+
+
+subroutine test_invalid2_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+   real(wp) :: xyz(3, 1)
+
+   xyz(:, 1) = [0.0_wp, 0.0_wp, 0.0_wp]
+
+   call new(struc, [character(len=2) :: "N "], xyz)
+   allocate(struc%pdb(struc%nat))
+
+   struc%pdb(1)%residue = "SER"
+   struc%pdb(1)%chains = "A"
+   struc%pdb(1)%residue_number = 1
+   struc%pdb(1)%occupancy = -0.10_wp
+
+   open(status='scratch', newunit=unit)
+   call write_pdb(struc, unit, error=error)
+   close(unit)
+
+end subroutine test_invalid2_pdb
 
 
 end module test_write_pdb

--- a/test/test_write_pdb.f90
+++ b/test/test_write_pdb.f90
@@ -13,12 +13,13 @@
 ! limitations under the License.
 
 module test_write_pdb
+   use, intrinsic :: ieee_arithmetic, only : ieee_quiet_nan, ieee_value
    use mctc_env_accuracy, only : wp
    use mctc_env_testing, only : new_unittest, unittest_type, error_type, check
    use testsuite_structure, only : get_structure
-   use mctc_io_write_pdb
-   use mctc_io_read_pdb
-   use mctc_io_structure
+   use mctc_io_write_pdb, only : write_pdb
+   use mctc_io_read_pdb, only : read_pdb
+   use mctc_io_structure, only : structure_type, new
    implicit none
    private
 
@@ -38,7 +39,8 @@ subroutine collect_write_pdb(testsuite)
       & new_unittest("valid1-pdb", test_valid1_pdb), &
       & new_unittest("valid2-pdb", test_valid2_pdb), &
       & new_unittest("invalid1-pdb", test_invalid1_pdb, should_fail=.true.), &
-      & new_unittest("invalid2-pdb", test_invalid2_pdb, should_fail=.true.) &
+      & new_unittest("invalid2-pdb", test_invalid2_pdb, should_fail=.true.), &
+      & new_unittest("invalid3-pdb", test_invalid3_pdb, should_fail=.true.) &
       & ]
 
 end subroutine collect_write_pdb
@@ -177,6 +179,33 @@ subroutine test_invalid2_pdb(error)
    close(unit)
 
 end subroutine test_invalid2_pdb
+
+
+subroutine test_invalid3_pdb(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+   real(wp) :: xyz(3, 1)
+
+   xyz(:, 1) = [0.0_wp, 0.0_wp, 0.0_wp]
+
+   call new(struc, [character(len=2) :: "O "], xyz)
+   allocate(struc%pdb(struc%nat))
+
+   struc%pdb(1)%residue = "HOH"
+   struc%pdb(1)%chains = "A"
+   struc%pdb(1)%residue_number = 1
+   ! NaN value for the occupancy, which is unphysical
+   struc%pdb(1)%occupancy = ieee_value(0.0_wp, ieee_quiet_nan)
+
+   open(status='scratch', newunit=unit)
+   call write_pdb(struc, unit, error=error)
+   close(unit)
+
+end subroutine test_invalid3_pdb
 
 
 end module test_write_pdb


### PR DESCRIPTION
in the documentation it is said that fractional site occupancies are not supported. Further it was a feature requested in 
grimme-lab/xtb#194 and as we plan to use mctc-lib upstream fully i think its a good idea to implement it here directly

For me it compiled sucessfully with gfortran 13.3.0 and with fpm 10.1 as a build system