### PR TITLE
Conversion to Debye and Buckingham

### DIFF
--- a/src/mctc/io/convert.f90
+++ b/src/mctc/io/convert.f90
@@ -100,4 +100,10 @@ module mctc_io_convert
    !> Debye to atomic dipole moment units (a.u.)
    real(wp), public, parameter :: dtoau = 1.0_wp/autod
 
+   !> Atomic quadrupole moment units (a.u.) to Buckingham
+   real(wp), public, parameter :: autoq = codata%e*bohr**2*codata%c*1e31_wp
+
+   !> Buckingham to atomic quadrupole moment units (a.u.)
+   real(wp), public, parameter :: qtoau = 1.0_wp/autoq
+
 end module mctc_io_convert

--- a/src/mctc/io/convert.f90
+++ b/src/mctc/io/convert.f90
@@ -95,7 +95,7 @@ module mctc_io_convert
    real(wp), public, parameter :: ctoau = 1.0_wp/autoc
 
    !> Atomic dipole moment units (a.u.) to Debye
-   real(wp), public, parameter :: autod = codata%e*bohr*codata%c/1e21_wp
+   real(wp), public, parameter :: autod = codata%e*bohr*codata%c*1e21_wp
 
    !> Debye to atomic dipole moment units (a.u.)
    real(wp), public, parameter :: dtoau = 1.0_wp/autod

--- a/src/mctc/io/convert.f90
+++ b/src/mctc/io/convert.f90
@@ -94,5 +94,10 @@ module mctc_io_convert
    !> Atomic charge units to Coulomb
    real(wp), public, parameter :: ctoau = 1.0_wp/autoc
 
+   !> Atomic dipole moment units (a.u.) to Debye
+   real(wp), public, parameter :: autod = codata%e*bohr
+
+   !> Debye to atomic dipole moment units (a.u.)
+   real(wp), public, parameter :: dtoau = 1.0_wp/autod
 
 end module mctc_io_convert

--- a/src/mctc/io/convert.f90
+++ b/src/mctc/io/convert.f90
@@ -95,7 +95,7 @@ module mctc_io_convert
    real(wp), public, parameter :: ctoau = 1.0_wp/autoc
 
    !> Atomic dipole moment units (a.u.) to Debye
-   real(wp), public, parameter :: autod = codata%e*bohr/codata%c*1e21_wp
+   real(wp), public, parameter :: autod = codata%e*bohr*codata%c/1e21_wp
 
    !> Debye to atomic dipole moment units (a.u.)
    real(wp), public, parameter :: dtoau = 1.0_wp/autod

--- a/src/mctc/io/convert.f90
+++ b/src/mctc/io/convert.f90
@@ -95,7 +95,7 @@ module mctc_io_convert
    real(wp), public, parameter :: ctoau = 1.0_wp/autoc
 
    !> Atomic dipole moment units (a.u.) to Debye
-   real(wp), public, parameter :: autod = codata%e*bohr
+   real(wp), public, parameter :: autod = codata%e*bohr/codata%c*1e21_wp
 
    !> Debye to atomic dipole moment units (a.u.)
    real(wp), public, parameter :: dtoau = 1.0_wp/autod


### PR DESCRIPTION
Adds the combined conversion constants from atomic units to Debye and Buckingham for dipole and quadrupole moment outputs. 