### PR TITLE
CMake: Move target inclusion after dependency discovery

### DIFF
--- a/config/template-config.cmake
+++ b/config/template-config.cmake
@@ -8,7 +8,6 @@ set(MCTCLIB_USE_TOMLF @MCTCLIB_USE_TOMLF@)
 enable_language("Fortran")
 
 if(NOT TARGET "@PROJECT_NAME@::@PROJECT_NAME@")
-  include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
   include(CMakeFindDependencyMacro)
 
   if(NOT TARGET "OpenMP::OpenMP_Fortran" AND MCTCLIB_WITH_OpenMP)
@@ -22,4 +21,6 @@ if(NOT TARGET "@PROJECT_NAME@::@PROJECT_NAME@")
   if(NOT TARGET "jonquil::jonquil" AND MCTCLIB_USE_JONQUIL)
     find_dependency("jonquil")
   endif()
+
+  include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 endif()


### PR DESCRIPTION
Including CMake target file before dependency discovery will cause CMake failure such as:
```
 CMake Error at /opt/test/cp2k-spack/spack/spack/opt/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__sp/linux-skylake/mctc-lib-0.4.2-yf4ytpd2bs4tp5yv7p5tdz5ymxiw5ra5/lib64/cmake/mctc-lib/mctc-lib-targets.cmake:68 (set_target_properties):
    The link interface of target "mctc-lib::mctc-lib-lib" contains:
  
      OpenMP::OpenMP_Fortran
  
    but the target was not found.  Possible reasons include:
```