### PR TITLE
Add coordination-number Hessian support

### DIFF
--- a/src/mctc/ncoord/dexp.f90
+++ b/src/mctc/ncoord/dexp.f90
@@ -33,6 +33,8 @@ module mctc_ncoord_dexp
       procedure :: ncoord_count
       !> Evaluates the derivative of the dexp counting function
       procedure :: ncoord_dcount
+      !> Evaluates the second derivative of the dexp counting function
+      procedure :: ncoord_d2count
    end type dexp_ncoord_type
 
    !> Steepness of first counting function
@@ -124,6 +126,27 @@ elemental function ncoord_dcount(self, izp, jzp, r) result(count)
 
 end function ncoord_dcount
 
+!> Second derivative of the double-exponential counting function w.r.t. the distance.
+elemental function ncoord_d2count(self, izp, jzp, r) result(count)
+   !> Coordination number container
+   class(dexp_ncoord_type), intent(in) :: self
+   !> Atom i index
+   integer, intent(in) :: izp
+   !> Atom j index
+   integer, intent(in) :: jzp
+   !> Current distance.
+   real(wp), intent(in) :: r
+
+   real(wp) :: rc, count
+
+   rc = self%rcov(izp) + self%rcov(jzp)
+
+   count = exp_d2count(ka, r, rc)*exp_count(kb, r, rc + r_shift) &
+      & + 2.0_wp*exp_dcount(ka, r, rc)*exp_dcount(kb, r, rc + r_shift) &
+      & + exp_count(ka, r, rc)*exp_d2count(kb, r, rc + r_shift)
+
+end function ncoord_d2count
+
 
 !> Mono-exponential counting function for coordination number contributions.
 elemental function exp_count(k, r, r0) result(count)
@@ -156,5 +179,24 @@ elemental function exp_dcount(k, r, r0) result(count)
    count = (-k*r0*expterm)/(r**2.0_wp*((expterm+1.0_wp)**2.0_wp))
 
 end function exp_dcount
+
+!> Second derivative of the mono-exponential counting function w.r.t. the distance.
+elemental function exp_d2count(k, r, r0) result(count)
+   !> Steepness of the counting function.
+   real(wp), intent(in) :: k
+   !> Current distance.
+   real(wp), intent(in) :: r
+   !> Cutoff radius.
+   real(wp), intent(in) :: r0
+
+   real(wp) :: count, cf, tmp
+
+   cf = exp_count(k, r, r0)
+   tmp = cf*(1.0_wp - cf)
+
+   count = tmp*(1.0_wp - 2.0_wp*cf)*(k*r0)**2/r**4 &
+      & + 2.0_wp*tmp*k*r0/r**3
+
+end function exp_d2count
 
 end module mctc_ncoord_dexp

--- a/src/mctc/ncoord/erf.f90
+++ b/src/mctc/ncoord/erf.f90
@@ -35,6 +35,8 @@ module mctc_ncoord_erf
       procedure :: ncoord_count
       !> Evaluates the derivative of the error counting function
       procedure :: ncoord_dcount
+      !> Evaluates the second derivative of the error counting function
+      procedure :: ncoord_d2count
    end type erf_ncoord_type
 
    !> Steepness of counting function
@@ -140,5 +142,29 @@ contains
       count = -(self%kcn*expterm)/(sqrtpi*rc**self%norm_exp)
 
    end function ncoord_dcount
+
+
+   !> Second derivative of the error counting function w.r.t. the distance.
+   elemental function ncoord_d2count(self, izp, jzp, r) result(count)
+      !> Coordination number container
+      class(erf_ncoord_type), intent(in) :: self
+      !> Atom i index
+      integer, intent(in) :: izp
+      !> Atom j index
+      integer, intent(in) :: jzp
+      !> Current distance.
+      real(wp), intent(in) :: r
+
+      real(wp), parameter :: sqrtpi = sqrt(pi)
+      real(wp) :: rc, exponent, expterm, count, rcn
+
+      rc = self%rcov(izp) + self%rcov(jzp)
+      rcn = rc**self%norm_exp
+
+      exponent = self%kcn*(r - rc)/rcn
+      expterm = exp(-exponent**2)
+      count = 2.0_wp*self%kcn**2*exponent*expterm/(sqrtpi*rcn**2)
+
+   end function ncoord_d2count
 
 end module mctc_ncoord_erf

--- a/src/mctc/ncoord/exp.f90
+++ b/src/mctc/ncoord/exp.f90
@@ -32,6 +32,8 @@ module mctc_ncoord_exp
       procedure :: ncoord_count
       !> Evaluates the derivative of the exponential counting function
       procedure :: ncoord_dcount
+      !> Evaluates the second derivative of the exponential counting function
+      procedure :: ncoord_d2count
    end type exp_ncoord_type
 
    !> Steepness of counting function
@@ -125,5 +127,28 @@ contains
       count = (-self%kcn*rc*expterm)/(r**2.0_wp*((expterm+1.0_wp)**2.0_wp))
 
    end function ncoord_dcount
+
+
+   !> Second derivative of the exponential counting function w.r.t. the distance.
+   elemental function ncoord_d2count(self, izp, jzp, r) result(count)
+      !> Coordination number container
+      class(exp_ncoord_type), intent(in) :: self
+      !> Atom i index
+      integer, intent(in) :: izp
+      !> Atom j index
+      integer, intent(in) :: jzp
+      !> Current distance.
+      real(wp), intent(in) :: r
+
+      real(wp) :: rc, cf, tmp, count
+
+      rc = self%rcov(izp) + self%rcov(jzp)
+      cf = 1.0_wp/(1.0_wp + exp(-self%kcn*(rc/r - 1.0_wp)))
+      tmp = cf*(1.0_wp - cf)
+
+      count = tmp*(1.0_wp - 2.0_wp*cf)*(self%kcn*rc)**2/r**4 &
+         & + 2.0_wp*tmp*self%kcn*rc/r**3
+
+   end function ncoord_d2count
 
 end module mctc_ncoord_exp

--- a/src/mctc/ncoord/type.f90
+++ b/src/mctc/ncoord/type.f90
@@ -46,10 +46,15 @@ module mctc_ncoord_type
       procedure :: get_en_factor
       !> Add CN derivative of an arbitrary function
       procedure :: add_coordination_number_derivs
+      !> Add dE/dCN contracted with the Cartesian CN Hessian
+      procedure :: add_coordination_number_hessian
       !> Evaluates the counting function (exp, dexp, erf, ...)
       procedure(ncoord_count),  deferred :: ncoord_count
       !> Evaluates the derivative of the counting function (exp, dexp, erf, ...)
       procedure(ncoord_dcount), deferred :: ncoord_dcount
+      !> Evaluates the second derivative of the counting function
+      !> Analytic implementations can override the numerical fallback.
+      procedure :: ncoord_d2count
    end type ncoord_type
 
    abstract interface
@@ -87,6 +92,29 @@ module mctc_ncoord_type
    end interface
 
 contains
+
+   !> Numerical fallback for the second derivative of the counting function
+   !> w.r.t. the distance. Built-in counting functions override this routine
+   !> with analytic expressions.
+   elemental function ncoord_d2count(self, izp, jzp, r) result(count)
+      !> Instance of coordination number container
+      class(ncoord_type), intent(in) :: self
+      !> Atom i index
+      integer, intent(in) :: izp
+      !> Atom j index
+      integer, intent(in) :: jzp
+      !> Current distance
+      real(wp), intent(in) :: r
+
+      real(wp) :: count, step
+      real(wp), parameter :: eps = epsilon(1.0_wp)**(1.0_wp/3.0_wp)
+
+      step = min(0.5_wp*r, eps*max(abs(r), 1.0_wp))
+      count = (self%ncoord_dcount(izp, jzp, r + step) &
+         & - self%ncoord_dcount(izp, jzp, r - step))/(2.0_wp*step)
+
+   end function ncoord_d2count
+
 
    !> Wrapper for CN using the CN cutoff for the lattice
    subroutine get_cn(self, mol, cn, dcndr, dcndL)
@@ -350,6 +378,113 @@ contains
       !$omp end parallel
 
    end subroutine add_coordination_number_derivs
+
+
+   !> Add dE/dCN contracted with the Cartesian Hessian of the
+   !> coordination numbers.
+   !>
+   !> The derivative dEdcn is contracted directly with the second derivative
+   !> of the underlying pairwise coordination-number counting function.  As for
+   !> add_coordination_number_derivs, the optional post-processing controlled by
+   !> self%cut is not part of this contraction.
+   subroutine add_coordination_number_hessian(self, mol, trans, dEdcn, hessian)
+
+      !> Coordination number container
+      class(ncoord_type), intent(in) :: self
+
+      !> Molecular structure data
+      type(structure_type), intent(in) :: mol
+
+      !> Lattice points
+      real(wp), intent(in) :: trans(:, :)
+
+      !> Derivative of expression with respect to the coordination number
+      real(wp), intent(in) :: dEdcn(:)
+
+      !> Cartesian Hessian in flattened (3*nat, 3*nat) representation
+      real(wp), intent(inout) :: hessian(:, :)
+
+      integer :: ipair, npair, iat, jat, izp, jzp, itr
+      integer :: ic, jc, ii, jj
+      real(wp) :: r2, r1, rij(3), cutoff2, den, dEdcnij
+      real(wp) :: countd, countd2, block(3, 3), pair_block(3, 3)
+
+      ! Only diagonal Cartesian blocks receive contributions from more than one
+      ! unordered atom pair. Keep those thread-private and write off-diagonal
+      ! blocks directly from the thread owning the pair.
+      real(wp), allocatable :: diagonal_local(:, :, :)
+
+      cutoff2 = self%cutoff**2
+      npair = mol%nat*(mol%nat - 1)/2
+
+      !$omp parallel default(none) &
+      !$omp shared(self, mol, trans, cutoff2, dEdcn, hessian, npair) &
+      !$omp private(ipair, iat, jat, izp, jzp, itr, ic, jc, ii, jj, r2, r1, rij, &
+      !$omp& den, dEdcnij, countd, countd2, block, pair_block, diagonal_local)
+      allocate(diagonal_local(3, 3, mol%nat), source=0.0_wp)
+
+      !$omp do schedule(runtime)
+      do ipair = 1, npair
+         iat = int(0.5_wp*(1.0_wp + sqrt(8.0_wp*real(ipair, wp) + 1.0_wp)))
+         if (iat*(iat - 1)/2 < ipair) iat = iat + 1
+         jat = ipair - (iat - 1)*(iat - 2)/2
+
+         izp = mol%id(iat)
+         jzp = mol%id(jat)
+         den = self%get_en_factor(izp, jzp)
+         dEdcnij = dEdcn(iat) + dEdcn(jat)*self%directed_factor
+
+         pair_block(:, :) = 0.0_wp
+         do itr = 1, size(trans, dim=2)
+            rij = mol%xyz(:, iat) - (mol%xyz(:, jat) + trans(:, itr))
+            r2 = sum(rij**2)
+            if (r2 > cutoff2 .or. r2 < 1.0e-12_wp) cycle
+            r1 = sqrt(r2)
+
+            countd = den*self%ncoord_dcount(izp, jzp, r1)
+            countd2 = den*self%ncoord_d2count(izp, jzp, r1)
+
+            do ic = 1, 3
+               do jc = 1, 3
+                  block(ic, jc) = dEdcnij * ( &
+                     & countd2*rij(ic)*rij(jc)/r2 &
+                     & - countd*rij(ic)*rij(jc)/(r2*r1))
+               end do
+               block(ic, ic) = block(ic, ic) + dEdcnij*countd/r1
+            end do
+            pair_block(:, :) = pair_block(:, :) + block(:, :)
+         end do
+
+         diagonal_local(:, :, iat) = diagonal_local(:, :, iat) + pair_block(:, :)
+         diagonal_local(:, :, jat) = diagonal_local(:, :, jat) + pair_block(:, :)
+
+         do ic = 1, 3
+            ii = 3*(iat - 1) + ic
+            do jc = 1, 3
+               jj = 3*(jat - 1) + jc
+               hessian(ii, jj) = hessian(ii, jj) - pair_block(ic, jc)
+               hessian(jj, ii) = hessian(jj, ii) - pair_block(jc, ic)
+            end do
+         end do
+      end do
+      !$omp end do nowait
+
+      !$omp critical (add_coordination_number_hessian_)
+      do iat = 1, mol%nat
+         do ic = 1, 3
+            ii = 3*(iat - 1) + ic
+            do jc = 1, 3
+               jj = 3*(iat - 1) + jc
+               hessian(ii, jj) = hessian(ii, jj) + diagonal_local(ic, jc, iat)
+            end do
+         end do
+      end do
+      !$omp end critical (add_coordination_number_hessian_)
+
+      deallocate(diagonal_local)
+      !$omp end parallel
+
+   end subroutine add_coordination_number_hessian
 
 
    !> Evaluates pairwise electronegativity factor if non applies

--- a/test/test_ncoord.f90
+++ b/test/test_ncoord.f90
@@ -54,6 +54,7 @@ contains
       & new_unittest("dcndr-mb04_dexp", test_dcndr_mb04_dexp), &
       & new_unittest("dcndr-mb05_dexp", test_dcndr_mb05_dexp), &
       & new_unittest("dcndr-ammonia_dexp", test_dcndr_ammonia_dexp), &
+      & new_unittest("hessian-mb04_dexp", test_hessian_mb04_dexp), &
       & new_unittest("dcndL-mb06_dexp", test_dcndL_mb06_dexp), &
       & new_unittest("dcndL-mb07_dexp", test_dcndL_mb07_dexp), &
       & new_unittest("dcndL-antracene_dexp", test_dcndL_anthracene_dexp), &
@@ -65,6 +66,7 @@ contains
       & new_unittest("dcndr-mb04_exp", test_dcndr_mb04_exp), &
       & new_unittest("dcndr-mb05_exp", test_dcndr_mb05_exp), &
       & new_unittest("dcndr-ammonia_exp", test_dcndr_ammonia_exp), &
+      & new_unittest("hessian-mb04_exp", test_hessian_mb04_exp), &
       & new_unittest("dcndL-mb06_exp", test_dcndL_mb06_exp), &
       & new_unittest("dcndL-mb07_exp", test_dcndL_mb07_exp), &
       & new_unittest("dcndL-antracene_exp", test_dcndL_anthracene_exp), &
@@ -76,6 +78,7 @@ contains
       & new_unittest("dcndr-mb04_erf", test_dcndr_mb04_erf), &
       & new_unittest("dcndr-mb05_erf", test_dcndr_mb05_erf), &
       & new_unittest("dcndr-ammonia_erf", test_dcndr_ammonia_erf), &
+      & new_unittest("hessian-mb04_erf", test_hessian_mb04_erf), &
       & new_unittest("dcndL-mb06_erf", test_dcndL_mb06_erf), &
       & new_unittest("dcndL-mb07_erf", test_dcndL_mb07_erf), &
       & new_unittest("dcndL-antracene_erf", test_dcndL_anthracene_erf), &
@@ -87,6 +90,7 @@ contains
       & new_unittest("dcndr-mb04_erf_en", test_dcndr_mb04_erf_en), &
       & new_unittest("dcndr-mb05_erf_en", test_dcndr_mb05_erf_en), &
       & new_unittest("dcndr-ammonia_erf_en", test_dcndr_ammonia_erf_en), &
+      & new_unittest("hessian-mb04_erf_en", test_hessian_mb04_erf_en), &
       & new_unittest("dcndL-mb06_erf_en", test_dcndL_mb06_erf_en), &
       & new_unittest("dcndL-mb07_erf_en", test_dcndL_mb07_erf_en), &
       & new_unittest("dcndL-antracene_erf_en", test_dcndL_anthracene_erf_en), &
@@ -100,6 +104,7 @@ contains
       & new_unittest("dcndr-mb04_erf_dftd4", test_dcndr_mb04_erf_dftd4), &
       & new_unittest("dcndr-mb05_erf_dftd4", test_dcndr_mb05_erf_dftd4), &
       & new_unittest("dcndr-ammonia_erf_dftd4", test_dcndr_ammonia_erf_dftd4), &
+      & new_unittest("hessian-ammonia_erf_dftd4", test_hessian_ammonia_erf_dftd4), &
       & new_unittest("dcndL-mb06_erf_dftd4", test_dcndL_mb06_erf_dftd4), &
       & new_unittest("dcndL-mb07_erf_dftd4", test_dcndL_mb07_erf_dftd4), &
       & new_unittest("dcndL-antracene_erf_dftd4", test_dcndL_anthracene_erf_dftd4), &
@@ -182,6 +187,130 @@ contains
       end if
 
    end subroutine test_numgrad
+
+
+   subroutine test_numhessian(error, mol, ncoord)
+
+      !> Error handling
+      type(error_type), allocatable, intent(out) :: error
+
+      !> Molecular structure data
+      type(structure_type), intent(inout) :: mol
+
+      !> Coordination number type
+      class(ncoord_type), intent(in) :: ncoord
+
+      integer :: iat, ic, ii
+      real(wp), allocatable :: dEdcn(:), gradient(:, :), gr(:, :), gl(:, :)
+      real(wp), allocatable :: hessian(:, :), numhessian(:, :), lattr(:, :)
+      real(wp) :: sigma(3, 3)
+      real(wp), parameter :: step = 1.0e-5_wp
+      real(wp), parameter :: hthr = 100.0_wp*thr2
+
+      allocate(dEdcn(mol%nat), gradient(3, mol%nat), gr(3, mol%nat), &
+         & gl(3, mol%nat), hessian(3*mol%nat, 3*mol%nat), &
+         & numhessian(3*mol%nat, 3*mol%nat))
+
+      do iat = 1, mol%nat
+         dEdcn(iat) = 0.125_wp*real(iat, wp) - 0.375_wp
+      end do
+
+      call get_lattice_points(mol%periodic, mol%lattice, ncoord%cutoff, lattr)
+
+      hessian(:, :) = 0.0_wp
+      call ncoord%add_coordination_number_hessian(mol, lattr, dEdcn, hessian)
+
+      do iat = 1, mol%nat
+         do ic = 1, 3
+            mol%xyz(ic, iat) = mol%xyz(ic, iat) + step
+            gradient(:, :) = 0.0_wp
+            sigma(:, :) = 0.0_wp
+            call ncoord%add_coordination_number_derivs(mol, lattr, dEdcn, gradient, sigma)
+            gr(:, :) = gradient(:, :)
+
+            mol%xyz(ic, iat) = mol%xyz(ic, iat) - 2.0_wp*step
+            gradient(:, :) = 0.0_wp
+            sigma(:, :) = 0.0_wp
+            call ncoord%add_coordination_number_derivs(mol, lattr, dEdcn, gradient, sigma)
+            gl(:, :) = gradient(:, :)
+
+            mol%xyz(ic, iat) = mol%xyz(ic, iat) + step
+            ii = 3*(iat - 1) + ic
+            numhessian(:, ii) = reshape(0.5_wp*(gr - gl)/step, [3*mol%nat])
+         end do
+      end do
+
+      if (maxval(abs(hessian - numhessian)) > hthr) then
+         call test_failed(error, "Coordination number Hessian does not match numerical derivative")
+         print "(a,es21.14)", "Max Hessian deviation: ", maxval(abs(hessian - numhessian))
+         return
+      end if
+
+      if (maxval(abs(hessian - transpose(hessian))) > 1000.0_wp*epsilon(1.0_wp)) then
+         call test_failed(error, "Coordination number Hessian is not symmetric")
+         return
+      end if
+
+      if (maxval(abs(sum(hessian, dim=2))) > 1000.0_wp*epsilon(1.0_wp)) then
+         call test_failed(error, "Coordination number Hessian violates translational invariance")
+      end if
+
+   end subroutine test_numhessian
+
+
+   subroutine test_hessian_mb04_dexp(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(structure_type) :: mol
+      type(dexp_ncoord_type) :: ncoord
+
+      call get_structure(mol, "mindless04")
+      call new_dexp_ncoord(ncoord, mol, cutoff=30.0_wp)
+      call test_numhessian(error, mol, ncoord)
+   end subroutine test_hessian_mb04_dexp
+
+
+   subroutine test_hessian_mb04_exp(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(structure_type) :: mol
+      type(exp_ncoord_type) :: ncoord
+
+      call get_structure(mol, "mindless04")
+      call new_exp_ncoord(ncoord, mol, cutoff=30.0_wp)
+      call test_numhessian(error, mol, ncoord)
+   end subroutine test_hessian_mb04_exp
+
+
+   subroutine test_hessian_mb04_erf(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(structure_type) :: mol
+      type(erf_ncoord_type) :: ncoord
+
+      call get_structure(mol, "mindless04")
+      call new_erf_ncoord(ncoord, mol, cutoff=30.0_wp, norm_exp=0.8_wp)
+      call test_numhessian(error, mol, ncoord)
+   end subroutine test_hessian_mb04_erf
+
+
+   subroutine test_hessian_mb04_erf_en(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(structure_type) :: mol
+      type(erf_en_ncoord_type) :: ncoord
+
+      call get_structure(mol, "mindless04")
+      call new_erf_en_ncoord(ncoord, mol, cutoff=30.0_wp)
+      call test_numhessian(error, mol, ncoord)
+   end subroutine test_hessian_mb04_erf_en
+
+
+   subroutine test_hessian_ammonia_erf_dftd4(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(structure_type) :: mol
+      type(erf_dftd4_ncoord_type) :: ncoord
+
+      call get_structure(mol, "x04")
+      call new_erf_dftd4_ncoord(ncoord, mol, cutoff=12.0_wp)
+      call test_numhessian(error, mol, ncoord)
+   end subroutine test_hessian_ammonia_erf_dftd4
 
 
    subroutine test_numsigma(error, mol, ncoord)


### PR DESCRIPTION
This PR adds second derivatives for coordination-number counting functions and a contracted Cartesian Hessian interface. With this PR implemented, downstream projects such as s-dftd3 and dftd4 can reuse the coordination-number Hessian implementation instead of maintaining their own copies.

The new `add_coordination_number_hessian` routine evaluates

$$
\sum_i
\frac{\partial E}{\partial CN_i}
\frac{\partial^2 CN_i}{\partial R_a \partial R_b}
$$

without constructing the full per-atom coordination-number Hessian.

Analytical second derivatives are implemented for the built-in exponential, double-exponential, and error-function counting functions. Existing derived error-function models, including D4 and electronegativity-weighted coordination numbers, reuse the same implementation.

The Hessian contraction is OpenMP-parallelized over atom pairs with only (O(N)) thread-local storage. A numerical fallback is provided for custom `ncoord_type` implementations that do not override the second derivative.

Tests compare the analytical Hessian against finite differences of the existing coordination-number derivative contraction, including exponential, directed, D4, and periodic cases.