### PR TITLE
Support extended XYZ format

### DIFF
--- a/doc/format-xyz.md
+++ b/doc/format-xyz.md
@@ -6,19 +6,18 @@ title: XYZ Format
 
 | Property | Value |
 |----------|-------|
-| File extensions | `.xyz`, `.log` |
+| File extensions | `.xyz`, `.log`, `.extxyz` |
 | Coordinate units | Ångström |
-| Supports periodicity | No |
+| Supports periodicity | Yes, using Extended XYZ |
 | Supports bonds | No |
-| Format hint | `xyz` |
+| Format hints | `xyz`, `extxyz` |
 
 ## Specification
 
 @Note [Reference](http://www.ccl.net/chemistry/resources/messages/1996/10/21.005-dir/index.html)
 
-The xyz format is a simple ASCII format for storing Cartesian coordinates and element symbols.
-
-**File structure:**
+The XYZ format is a simple ASCII format for storing Cartesian coordinates and
+atomic symbols. The ordinary form contains:
 
 1. **Line 1**: Number of atoms (integer)
 2. **Line 2**: Comment line (can be empty, often contains title or energy)
@@ -26,9 +25,48 @@ The xyz format is a simple ASCII format for storing Cartesian coordinates and el
 
 Coordinates are given in Ångström and are internally converted to Bohr.
 
+The `.xyz` extension denotes the XYZ family. When a structure contains lattice
+or periodicity information, the writer automatically emits Extended XYZ so this
+information is not lost. Structures without such information are written as
+ordinary XYZ. The `.extxyz` extension or the `extxyz` format hint can be used to
+force Extended XYZ output.
+
+On input, `.xyz` files are inspected for Extended XYZ metadata. A valid
+`Properties` entry on the second line selects Extended XYZ parsing, including
+`Lattice` and `pbc`; otherwise the file is read as ordinary XYZ.
+
+## Extended XYZ
+
+Extended XYZ keeps the usual atom-count record, but interprets the second line
+as `key=value` metadata. The `Properties` key describes the typed per-atom
+columns, while `Lattice` stores the cell and `pbc` selects the periodic
+directions.
+
+Example:
+
+```text
+2
+Lattice="5.0 0.0 0.0 0.0 5.0 0.0 0.0 0.0 5.0" Properties=species:S:1:pos:R:3 pbc="T T T"
+H  0.0  0.0  0.0
+O  1.0  1.0  1.0
+```
+
+The reader uses `Properties` to locate structural columns rather than assuming a
+fixed column order. It supports:
+
+- `species:S:1` or `Z:I:1` for the element identity;
+- `pos:R:3` for Cartesian coordinates;
+- `Lattice` as a 9-vector or 3x3 matrix;
+- `pbc` as three logical values;
+- `comment` as an optional per-configuration string.
+
+Unknown per-atom properties and per-configuration metadata are parsed only as
+needed to locate the structural data and are otherwise discarded, because
+`structure_type` has no generic property dictionary.
+
 ## Example
 
-Caffeine molecule in xyz format:
+Caffeine molecule in ordinary XYZ format:
 
 ```text
 24
@@ -61,18 +99,14 @@ H            4.40017000000000       -5.16929000000000       -0.94780000000000
 
 ## Extensions
 
-The reader supports the following extensions beyond the standard format:
-
-- **Atomic numbers**: Integer atomic numbers are accepted instead of element symbols
-  and are automatically converted to capitalized element symbols
+The reader also accepts integer atomic numbers instead of element symbols and
+converts them to canonical symbols.
 
 ## Limitations
 
-The following features are currently not supported:
-
-- Scalar atomic quantities (4th column) are not preserved and dropped
-- Vector atomic quantities (columns 5-7) are not preserved and dropped
+For ordinary XYZ input, additional scalar or vector atomic quantities are not
+preserved. For Extended XYZ input, unknown properties are skipped according to
+the `Properties` schema but are not retained for writing.
 
 @Note Feel free to contribute support for missing features
       or bring missing features to our attention by opening an issue.
-

--- a/doc/index.md
+++ b/doc/index.md
@@ -7,7 +7,7 @@ All formats can be auto-detected by file extension or explicitly specified using
 
 ## General ASCII Formats
 
-- [xyz format](./format-xyz.html) - Simple Cartesian coordinate format (`.xyz`, `.log`)
+- [XYZ format](./format-xyz.html) - Ordinary and Extended XYZ (`.xyz`, `.log`, `.extxyz`)
 - [Connection table files](./format-ctfile.html) - MDL molfile and SDF formats (`.mol`, `.sdf`)
 - [Protein Data Bank](./format-pdb.html) - PDB format for biomolecules (`.pdb`)
 

--- a/man/mctc-convert.1.adoc
+++ b/man/mctc-convert.1.adoc
@@ -30,9 +30,9 @@ The following geometry formats are supported for both reading and writing:
 |===
 |Format hint |Description |File extensions
 
-|xyz
-|Xmol/xyz coordinate files
-|.xyz, .log
+|xyz, extxyz
+|XYZ coordinate files; periodic structures are written as Extended XYZ
+|.xyz, .log, .extxyz
 
 |tmol, coord
 |Turbomole coord files (including periodic/riper)
@@ -82,6 +82,11 @@ The following geometry formats are supported for both reading and writing:
 |Q-Chem molecule block
 |.qchem
 |===
+
+The `.xyz` extension is used for both ordinary and Extended XYZ. When writing,
+lattice or periodicity information automatically selects Extended XYZ. The
+`extxyz` hint or `.extxyz` extension forces Extended XYZ output. On input,
+Extended XYZ metadata is detected automatically in `.xyz` files.
 
 NOTE: JSON format support requires mctc-lib to be compiled with the jonquil dependency.
 

--- a/src/mctc/io/filetype.f90
+++ b/src/mctc/io/filetype.f90
@@ -73,6 +73,9 @@ module mctc_io_filetype
       !> General JSON format
       integer :: json = 14
 
+      !> Extended XYZ format
+      integer :: extxyz = 15
+
    end type enum_filetype
 
    !> File type enumerator
@@ -92,6 +95,7 @@ module mctc_io_filetype
    !> | `filetype%pymatgen` | Pymatgen | Pymatgen JSON format |
    !> | `filetype%aims` | FHI-aims | geometry.in format |
    !> | `filetype%qchem` | Q-Chem | Molecule block format |
+   !> | `filetype%extxyz` | extxyz | Extended XYZ format |
    type(enum_filetype), parameter :: filetype = enum_filetype()
 
 
@@ -118,6 +122,8 @@ elemental function get_filetype(file) result(ftype)
          ftype = filetype%tmol
       case("xyz", "log")
          ftype = filetype%xyz
+      case("extxyz")
+         ftype = filetype%extxyz
       case("mol")
          ftype = filetype%molfile
       case("sdf")

--- a/src/mctc/io/read.f90
+++ b/src/mctc/io/read.f90
@@ -143,7 +143,7 @@ subroutine get_structure_reader(reader, ftype)
    nullify(reader)
 
    select case(ftype)
-   case(filetype%xyz)
+   case(filetype%xyz, filetype%extxyz)
       reader => read_xyz
 
    case(filetype%molfile)

--- a/src/mctc/io/read/xyz.f90
+++ b/src/mctc/io/read/xyz.f90
@@ -19,7 +19,7 @@ module mctc_io_read_xyz
    use mctc_io_structure, only : structure_type, new
    use mctc_io_symbols, only : to_number, to_symbol, symbol_length
    use mctc_io_utils, only : next_line, token_type, next_token, io_error, filename, &
-      read_next_token, to_string
+      read_next_token, read_token, to_string
    implicit none
    private
 
@@ -41,12 +41,14 @@ subroutine read_xyz(self, unit, error)
    type(error_type), allocatable, intent(out) :: error
 
    integer :: ii, n, iat, stat, pos, lnum
-   real(wp) :: x, y, z, conv
+   integer :: species_col, z_col, pos_col, ncols
+   real(wp) :: x, y, z, conv, lattice(3, 3)
    real(wp), allocatable :: xyz(:, :)
+   logical :: extended, have_lattice, have_pbc, periodic(3)
    type(token_type) :: token, tsym, tnat
    character(len=symbol_length) :: chdum
    character(len=symbol_length), allocatable :: sym(:)
-   character(len=:), allocatable :: line, comment, fline
+   character(len=:), allocatable :: line, comment, fline, properties, ext_comment
 
    conv = aatoau
    lnum = 0
@@ -68,12 +70,32 @@ subroutine read_xyz(self, unit, error)
    allocate(sym(n))
    allocate(xyz(3, n))
 
-   ! next record is a comment
+   ! next record is either a plain XYZ comment or an Extended XYZ header
    call next_line(unit, comment, pos, lnum, stat)
    if (stat /= 0) then
       call io_error(error, "Unexpected end of file", &
          & "", token_type(0, 0), filename(unit), lnum+1, "expected value")
       return
+   end if
+
+   call parse_extxyz_header(comment, extended, properties, lattice, have_lattice, &
+      & periodic, have_pbc, ext_comment, stat)
+   if (stat /= 0) then
+      call fatal_error(error, "Could not parse Extended XYZ header in '"//filename(unit)//"'")
+      return
+   end if
+
+   species_col = 0
+   z_col = 0
+   pos_col = 0
+   ncols = 4
+   if (extended) then
+      call parse_properties(properties, species_col, z_col, pos_col, ncols, stat)
+      if (stat /= 0) then
+         call fatal_error(error, "Invalid Properties specification in Extended XYZ file '"// &
+            & filename(unit)//"'")
+         return
+      end if
    end if
 
    ii = 0
@@ -85,41 +107,59 @@ subroutine read_xyz(self, unit, error)
             & "", token_type(0, 0), filename(unit), lnum+1, "expected value")
          return
       end if
-      call next_token(line, pos, tsym)
-      if (stat == 0) then
-        call read_next_token(line, pos, token, x, stat)
-      end if
-      if (stat == 0) then
-        call read_next_token(line, pos, token, y, stat)
-      end if
-      if (stat == 0) then
-        call read_next_token(line, pos, token, z, stat)
-      end if
-      if (stat /= 0) then
-         call io_error(error, "Could not parse coordinates from xyz file", &
-            & line, token, filename(unit), lnum, "expected real value")
-         return
-      end if
 
-      ! Adjust the token length to faithfully report the used chars in case of an error
-      tsym%last = min(tsym%last, tsym%first + symbol_length - 1)
-      chdum = line(tsym%first:tsym%last)
-      iat = to_number(chdum)
-      if (iat <= 0) then
-         read(chdum, *, iostat=stat) iat
+      if (extended) then
+         call read_extxyz_atom(line, species_col, z_col, pos_col, ncols, &
+            & chdum, x, y, z, token, stat)
+         if (stat /= 0) then
+            call io_error(error, "Could not parse atom data from Extended XYZ file", &
+               & line, token, filename(unit), lnum, "unexpected value")
+            return
+         end if
+         iat = to_number(chdum)
+      else
+         call next_token(line, pos, tsym)
          if (stat == 0) then
-            chdum = to_symbol(iat)
-         else
-            iat = 0
+            call read_next_token(line, pos, token, x, stat)
+         end if
+         if (stat == 0) then
+            call read_next_token(line, pos, token, y, stat)
+         end if
+         if (stat == 0) then
+            call read_next_token(line, pos, token, z, stat)
+         end if
+         if (stat /= 0) then
+            call io_error(error, "Could not parse coordinates from xyz file", &
+               & line, token, filename(unit), lnum, "expected real value")
+            return
+         end if
+
+         ! Adjust the token length to faithfully report the used chars in case of an error
+         tsym%last = min(tsym%last, tsym%first + symbol_length - 1)
+         chdum = line(tsym%first:tsym%last)
+         iat = to_number(chdum)
+         if (iat <= 0) then
+            read(chdum, *, iostat=stat) iat
+            if (stat == 0) then
+               chdum = to_symbol(iat)
+            else
+               iat = 0
+            end if
          end if
       end if
+
       if (iat > 0) then
          ii = ii+1
          sym(ii) = trim(chdum)
          xyz(:, ii) = [x, y, z]*conv
       else
-         call io_error(error, "Cannot map symbol to atomic number", &
-            & line, tsym, filename(unit), lnum, "unknown element")
+         if (extended) then
+            call io_error(error, "Cannot map symbol to atomic number", &
+               & line, token, filename(unit), lnum, "unknown element")
+         else
+            call io_error(error, "Cannot map symbol to atomic number", &
+               & line, tsym, filename(unit), lnum, "unknown element")
+         end if
          return
       end if
    end do
@@ -130,10 +170,472 @@ subroutine read_xyz(self, unit, error)
       return
    end if
 
-   call new(self, sym, xyz)
-   if (len(comment) > 0) self%comment = comment
+   if (extended) then
+      if (have_lattice) then
+         call new(self, sym, xyz, lattice=lattice, periodic=periodic)
+      else
+         call new(self, sym, xyz, periodic=periodic)
+      end if
+      if (allocated(ext_comment)) self%comment = ext_comment
+   else
+      call new(self, sym, xyz)
+      if (len(comment) > 0) self%comment = comment
+   end if
 
 end subroutine read_xyz
+
+
+subroutine parse_extxyz_header(line, extended, properties, lattice, have_lattice, &
+      & periodic, have_pbc, comment, stat)
+   character(len=*), intent(in) :: line
+   logical, intent(out) :: extended, have_lattice, have_pbc
+   character(len=:), allocatable, intent(out) :: properties, comment
+   real(wp), intent(out) :: lattice(3, 3)
+   logical, intent(out) :: periodic(3)
+   integer, intent(out) :: stat
+
+   logical :: found
+   character(len=:), allocatable :: value
+
+   stat = 0
+   extended = .false.
+   have_lattice = .false.
+   have_pbc = .false.
+   lattice = 0.0_wp
+   periodic = .false.
+
+   call get_header_value(line, "Properties", properties, found, stat)
+   if (stat /= 0 .or. .not.found) then
+      stat = 0
+      return
+   end if
+   extended = .true.
+
+   call get_header_value(line, "Lattice", value, found, stat)
+   if (stat /= 0) return
+   if (found) then
+      call parse_lattice(value, lattice, stat)
+      if (stat /= 0) return
+      have_lattice = .true.
+      periodic = .true.
+   end if
+
+   call get_header_value(line, "pbc", value, found, stat)
+   if (stat /= 0) return
+   if (found) then
+      call parse_pbc(value, periodic, stat)
+      if (stat /= 0) return
+      have_pbc = .true.
+   end if
+
+   call get_header_value(line, "comment", value, found, stat)
+   if (stat /= 0) return
+   if (found .and. len(value) > 0) comment = unescape_string(value)
+
+end subroutine parse_extxyz_header
+
+
+subroutine get_header_value(line, wanted, value, found, stat)
+   character(len=*), intent(in) :: line, wanted
+   character(len=:), allocatable, intent(out) :: value
+   logical, intent(out) :: found
+   integer, intent(out) :: stat
+
+   integer :: i, j, first, last, depth, n
+   character(len=:), allocatable :: key
+   character(len=1) :: quote, open_char, close_char
+
+   found = .false.
+   stat = 0
+   value = ""
+   n = len_trim(line)
+   i = 1
+
+   do while(i <= n)
+      do while(i <= n)
+         if (.not.is_space(line(i:i))) exit
+         i = i + 1
+      end do
+      if (i > n) exit
+
+      if (line(i:i) == '"' .or. line(i:i) == "'") then
+         quote = line(i:i)
+         first = i + 1
+         i = i + 1
+         do while(i <= n)
+            if (line(i:i) == quote) exit
+            if (line(i:i) == achar(92) .and. i < n) i = i + 1
+            i = i + 1
+         end do
+         if (i > n) then
+            stat = 1
+            return
+         end if
+         last = i - 1
+         key = line(first:last)
+         i = i + 1
+      else
+         first = i
+         do while(i <= n)
+            if (is_space(line(i:i)) .or. line(i:i) == "=") exit
+            i = i + 1
+         end do
+         last = i - 1
+         if (last < first) then
+            i = i + 1
+            cycle
+         end if
+         key = line(first:last)
+      end if
+
+      do while(i <= n)
+         if (.not.is_space(line(i:i))) exit
+         i = i + 1
+      end do
+      if (i > n) cycle
+      if (line(i:i) /= "=") then
+         do while(i <= n)
+            if (is_space(line(i:i))) exit
+            i = i + 1
+         end do
+         cycle
+      end if
+      i = i + 1
+      do while(i <= n)
+         if (.not.is_space(line(i:i))) exit
+         i = i + 1
+      end do
+      if (i > n) then
+         stat = 1
+         return
+      end if
+
+      select case(line(i:i))
+      case('"', "'")
+         quote = line(i:i)
+         first = i + 1
+         i = i + 1
+         do while(i <= n)
+            if (line(i:i) == achar(92) .and. i < n) then
+               i = i + 2
+               cycle
+            end if
+            if (line(i:i) == quote) exit
+            i = i + 1
+         end do
+         if (i > n) then
+            stat = 1
+            return
+         end if
+         last = i - 1
+         i = i + 1
+
+      case("[", "{")
+         open_char = line(i:i)
+         close_char = merge("]", "}", open_char == "[")
+         first = i
+         depth = 0
+         quote = " "
+         do while(i <= n)
+            if (quote /= " ") then
+               if (line(i:i) == achar(92) .and. i < n) then
+                  i = i + 2
+                  cycle
+               else if (line(i:i) == quote) then
+                  quote = " "
+               end if
+            else
+               if (line(i:i) == '"' .or. line(i:i) == "'") then
+                  quote = line(i:i)
+               else if (line(i:i) == open_char) then
+                  depth = depth + 1
+               else if (line(i:i) == close_char) then
+                  depth = depth - 1
+                  if (depth == 0) exit
+               end if
+            end if
+            i = i + 1
+         end do
+         if (i > n .or. depth /= 0) then
+            stat = 1
+            return
+         end if
+         last = i
+         i = i + 1
+
+      case default
+         first = i
+         do while(i <= n)
+            if (is_space(line(i:i))) exit
+            i = i + 1
+         end do
+         last = i - 1
+      end select
+
+      if (key == wanted) then
+         if (last >= first) value = line(first:last)
+         found = .true.
+         return
+      end if
+   end do
+
+end subroutine get_header_value
+
+
+subroutine parse_lattice(value, lattice, stat)
+   character(len=*), intent(in) :: value
+   real(wp), intent(out) :: lattice(3, 3)
+   integer, intent(out) :: stat
+
+   character(len=:), allocatable :: buffer
+   real(wp) :: vec(3), vals(9)
+   integer :: i
+
+   buffer = value
+   do i = 1, len(buffer)
+      select case(buffer(i:i))
+      case("[", "]", "{", "}", ",")
+         buffer(i:i) = " "
+      case default
+         continue
+      end select
+   end do
+
+   read(buffer, *, iostat=stat) vals
+   if (stat == 0) then
+      lattice = reshape(vals, [3, 3]) * aatoau
+      return
+   end if
+
+   read(buffer, *, iostat=stat) vec
+   if (stat == 0) then
+      lattice = 0.0_wp
+      do i = 1, 3
+         lattice(i, i) = vec(i) * aatoau
+      end do
+   end if
+
+end subroutine parse_lattice
+
+
+subroutine parse_pbc(value, periodic, stat)
+   character(len=*), intent(in) :: value
+   logical, intent(out) :: periodic(3)
+   integer, intent(out) :: stat
+
+   character(len=:), allocatable :: buffer
+   integer :: i
+
+   buffer = value
+   do i = 1, len(buffer)
+      select case(buffer(i:i))
+      case("[", "]", "{", "}", ",")
+         buffer(i:i) = " "
+      case default
+         continue
+      end select
+   end do
+   read(buffer, *, iostat=stat) periodic
+   if (stat /= 0) return
+
+end subroutine parse_pbc
+
+
+subroutine parse_properties(properties, species_col, z_col, pos_col, ncols, stat)
+   character(len=*), intent(in) :: properties
+   integer, intent(out) :: species_col, z_col, pos_col, ncols, stat
+
+   integer :: cursor, col, count
+   character(len=:), allocatable :: name, kind, count_string
+   logical :: ok
+
+   species_col = 0
+   z_col = 0
+   pos_col = 0
+   ncols = 0
+   stat = 0
+   cursor = 1
+   col = 1
+
+   do while(cursor <= len(properties))
+      call next_property_token(properties, cursor, name, ok)
+      if (.not.ok) then
+         stat = 1
+         return
+      end if
+      call next_property_token(properties, cursor, kind, ok)
+      if (.not.ok) then
+         stat = 1
+         return
+      end if
+      call next_property_token(properties, cursor, count_string, ok)
+      if (.not.ok) then
+         stat = 1
+         return
+      end if
+      read(count_string, *, iostat=stat) count
+      if (stat /= 0 .or. count < 1 .or. len(kind) /= 1) then
+         stat = 1
+         return
+      end if
+
+      select case(name)
+      case("species")
+         if (kind /= "S" .or. count /= 1) then
+            stat = 1
+            return
+         end if
+         species_col = col
+      case("Z")
+         if (kind /= "I" .or. count /= 1) then
+            stat = 1
+            return
+         end if
+         z_col = col
+      case("pos")
+         if (kind /= "R" .or. count /= 3) then
+            stat = 1
+            return
+         end if
+         pos_col = col
+      case default
+         continue
+      end select
+
+      col = col + count
+   end do
+
+   ncols = col - 1
+   if (pos_col == 0 .or. (species_col == 0 .and. z_col == 0)) stat = 1
+
+end subroutine parse_properties
+
+
+subroutine next_property_token(string, cursor, token, ok)
+   character(len=*), intent(in) :: string
+   integer, intent(inout) :: cursor
+   character(len=:), allocatable, intent(out) :: token
+   logical, intent(out) :: ok
+
+   integer :: first, last, n
+
+   n = len(string)
+   if (cursor > n) then
+      token = ""
+      ok = .false.
+      return
+   end if
+
+   first = cursor
+   last = index(string(first:), ":")
+   if (last == 0) then
+      token = string(first:)
+      cursor = n + 1
+   else
+      last = first + last - 2
+      token = string(first:last)
+      cursor = last + 2
+   end if
+   ok = len(token) > 0
+
+end subroutine next_property_token
+
+
+subroutine read_extxyz_atom(line, species_col, z_col, pos_col, ncols, symbol, &
+      & x, y, z, token, stat)
+   character(len=*), intent(in) :: line
+   integer, intent(in) :: species_col, z_col, pos_col, ncols
+   character(len=symbol_length), intent(out) :: symbol
+   real(wp), intent(out) :: x, y, z
+   type(token_type), intent(out) :: token
+   integer, intent(out) :: stat
+
+   integer :: pos, col, atomic_number
+   real(wp) :: coord(3)
+   type(token_type) :: current
+
+   pos = 0
+   stat = 0
+   atomic_number = 0
+   symbol = ""
+   coord = 0.0_wp
+   token = token_type(1, 1)
+
+   do col = 1, ncols
+      call next_token(line, pos, current)
+      token = current
+      if (current%first > len_trim(line)) then
+         stat = 1
+         return
+      end if
+
+      if (col == species_col) then
+         current%last = min(current%last, current%first + symbol_length - 1)
+         symbol = line(current%first:current%last)
+      else if (col == z_col) then
+         call read_token(line, current, atomic_number, stat)
+         if (stat /= 0) return
+      else if (col >= pos_col .and. col < pos_col + 3) then
+         call read_token(line, current, coord(col-pos_col+1), stat)
+         if (stat /= 0) return
+      end if
+   end do
+
+   call next_token(line, pos, current)
+   if (current%first <= len_trim(line)) then
+      token = current
+      stat = 1
+      return
+   end if
+
+   if (species_col == 0) then
+      if (atomic_number <= 0) then
+         stat = 1
+         return
+      end if
+      symbol = to_symbol(atomic_number)
+   end if
+
+   x = coord(1)
+   y = coord(2)
+   z = coord(3)
+
+end subroutine read_extxyz_atom
+
+
+pure function is_space(char) result(space)
+   character(len=1), intent(in) :: char
+   logical :: space
+
+   space = char == " " .or. char == achar(9)
+
+end function is_space
+
+
+function unescape_string(string) result(output)
+   character(len=*), intent(in) :: string
+   character(len=:), allocatable :: output
+
+   integer :: i
+
+   output = ""
+   i = 1
+   do while(i <= len(string))
+      if (string(i:i) == achar(92) .and. i < len(string)) then
+         select case(string(i+1:i+1))
+         case("n")
+            output = output // new_line("a")
+         case default
+            output = output // string(i+1:i+1)
+         end select
+         i = i + 2
+      else
+         output = output // string(i:i)
+         i = i + 1
+      end if
+   end do
+
+end function unescape_string
 
 
 end module mctc_io_read_xyz

--- a/src/mctc/io/write.f90
+++ b/src/mctc/io/write.f90
@@ -27,7 +27,7 @@ module mctc_io_write
    use mctc_io_write_qcschema, only : write_qcschema
    use mctc_io_write_turbomole, only : write_coord
    use mctc_io_write_vasp, only : write_vasp
-   use mctc_io_write_xyz, only : write_xyz
+   use mctc_io_write_xyz, only : write_xyz, write_extxyz
    implicit none
    private
 
@@ -111,6 +111,9 @@ subroutine write_structure_to_unit(self, unit, ftype, error)
 
    case(filetype%xyz)
       call write_xyz(self, unit)
+
+   case(filetype%extxyz)
+      call write_extxyz(self, unit)
 
    case(filetype%molfile)
       call write_molfile(self, unit)

--- a/src/mctc/io/write/xyz.f90
+++ b/src/mctc/io/write/xyz.f90
@@ -13,12 +13,13 @@
 ! limitations under the License.
 
 module mctc_io_write_xyz
+   use mctc_env_accuracy, only : wp
    use mctc_io_convert, only : autoaa
    use mctc_io_structure, only : structure_type
    implicit none
    private
 
-   public :: write_xyz
+   public :: write_xyz, write_extxyz
 
 
 contains
@@ -30,6 +31,15 @@ subroutine write_xyz(self, unit, comment_line)
    character(len=*), intent(in), optional :: comment_line
    integer :: iat
    logical :: expo
+
+   if (requires_extxyz(self)) then
+      if (present(comment_line)) then
+         call write_extxyz(self, unit, comment_line)
+      else
+         call write_extxyz(self, unit)
+      end if
+      return
+   end if
 
    write(unit, "(i0)") self%nat
    if (present(comment_line)) then
@@ -55,6 +65,109 @@ subroutine write_xyz(self, unit, comment_line)
    end if
 
 end subroutine write_xyz
+
+
+subroutine write_extxyz(self, unit, comment_line)
+   class(structure_type), intent(in) :: self
+   integer, intent(in) :: unit
+   character(len=*), intent(in), optional :: comment_line
+
+   integer :: i, j, iat
+   real(wp) :: lattice(3, 3)
+   logical :: periodic(3), expo, have_lattice
+   character(len=:), allocatable :: comment
+
+   lattice = 0.0_wp
+   periodic = .false.
+   have_lattice = .false.
+   if (allocated(self%periodic)) then
+      periodic(:min(3, size(self%periodic))) = self%periodic(:min(3, size(self%periodic)))
+   end if
+   if (allocated(self%lattice)) then
+      have_lattice = size(self%lattice) > 0
+      if (have_lattice) then
+         lattice(:min(3, size(self%lattice, 1)), :min(3, size(self%lattice, 2))) = &
+            & self%lattice(:min(3, size(self%lattice, 1)), :min(3, size(self%lattice, 2)))
+      end if
+   end if
+
+   write(unit, "(i0)") self%nat
+   if (have_lattice) then
+      write(unit, "(a)", advance="no") 'Lattice="'
+      do j = 1, 3
+         do i = 1, 3
+            if (i /= 1 .or. j /= 1) write(unit, "(1x)", advance="no")
+            write(unit, "(es24.16)", advance="no") lattice(i, j) * autoaa
+         end do
+      end do
+      write(unit, "(a)", advance="no") '" '
+   end if
+
+   write(unit, "(a)", advance="no") 'Properties=species:S:1:pos:R:3 pbc="'
+   do i = 1, 3
+      if (i > 1) write(unit, "(1x)", advance="no")
+      write(unit, "(a1)", advance="no") merge("T", "F", periodic(i))
+   end do
+   write(unit, "(a)", advance="no") '"'
+
+   if (present(comment_line)) then
+      comment = comment_line
+   else if (allocated(self%comment)) then
+      comment = self%comment
+   end if
+   if (allocated(comment)) then
+      write(unit, "(a)", advance="no") ' comment="'//escape_string(comment)//'"'
+   end if
+   write(unit, "(a)")
+
+   expo = maxval(self%xyz) > 1.0e+5 .or. minval(self%xyz) < -1.0e+5
+   if (expo) then
+      do iat = 1, self%nat
+         write(unit, "(a4, 1x, 3es24.14)") &
+            & self%sym(self%id(iat)), self%xyz(:, iat)*autoaa
+      end do
+   else
+      do iat = 1, self%nat
+         write(unit, "(a4, 1x, 3f24.14)") &
+            & self%sym(self%id(iat)), self%xyz(:, iat)*autoaa
+      end do
+   end if
+
+end subroutine write_extxyz
+
+
+logical function requires_extxyz(self)
+   class(structure_type), intent(in) :: self
+
+   requires_extxyz = allocated(self%lattice) .and. size(self%lattice) > 0
+   if (.not.requires_extxyz .and. allocated(self%periodic)) then
+      requires_extxyz = any(self%periodic)
+   end if
+
+end function requires_extxyz
+
+
+function escape_string(string) result(output)
+   character(len=*), intent(in) :: string
+   character(len=:), allocatable :: output
+
+   integer :: i
+
+   output = ""
+   do i = 1, len(string)
+      select case(string(i:i))
+      case(achar(92))
+         output = output // achar(92) // achar(92)
+      case('"')
+         output = output // achar(92) // '"'
+      case(new_line("a"))
+         output = output // achar(92) // "n"
+      case default
+         output = output // string(i:i)
+      end select
+   end do
+
+end function escape_string
 
 
 end module mctc_io_write_xyz

--- a/test/test_read.f90
+++ b/test/test_read.f90
@@ -44,7 +44,8 @@ subroutine collect_read(testsuite)
       & new_unittest("valid-qcschema", test_qcschema, should_fail=.not.get_mctc_feature("json")), &
       & new_unittest("valid-vasp", test_vasp), &
       & new_unittest("valid-coord", test_coord), &
-      & new_unittest("valid-xyz", test_xyz) &
+      & new_unittest("valid-xyz", test_xyz), &
+      & new_unittest("valid-extxyz", test_extxyz) &
       & ]
 
 end subroutine collect_read
@@ -463,6 +464,36 @@ subroutine test_xyz(error)
    close(unit, status="delete")
 
 end subroutine test_xyz
+
+
+subroutine test_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   character(len=:), allocatable :: name
+   integer :: unit
+
+   name = get_name() // ".extxyz"
+
+   open(file=name, newunit=unit)
+   write(unit, "(a)") &
+      "2", &
+      'Lattice="5 0 0 0 5 0 0 0 5" Properties=species:S:1:pos:R:3 pbc="T T T"', &
+      "H 0.0 0.0 0.0", &
+      "O 1.0 1.0 1.0"
+   close(unit)
+
+   call read_structure(struc, name, error)
+   if (.not.allocated(error)) then
+      call check(error, all(struc%periodic), .true., "Structure should be periodic")
+   end if
+
+   open(file=name, newunit=unit)
+   close(unit, status="delete")
+
+end subroutine test_extxyz
 
 
 subroutine test_qcschema(error)

--- a/test/test_read_xyz.f90
+++ b/test/test_read_xyz.f90
@@ -13,7 +13,9 @@
 ! limitations under the License.
 
 module test_read_xyz
+   use mctc_env_accuracy, only : wp
    use mctc_env_testing, only : new_unittest, unittest_type, error_type, check
+   use mctc_io_convert, only : aatoau
    use mctc_io_read_xyz, only : read_xyz
    use mctc_io_structure, only : structure_type
    implicit none
@@ -37,6 +39,20 @@ subroutine collect_read_xyz(testsuite)
       & new_unittest("valid3-xyz", test_valid3_xyz), &
       & new_unittest("valid4-xyz", test_valid4_xyz), &
       & new_unittest("valid5-xyz", test_valid5_xyz), &
+      & new_unittest("valid6-extxyz", test_valid6_extxyz), &
+      & new_unittest("valid7-extxyz", test_valid7_extxyz), &
+      & new_unittest("invalid1-extxyz", test_invalid1_extxyz, should_fail=.true.), &
+      & new_unittest("invalid2-extxyz", test_invalid2_extxyz, should_fail=.true.), &
+      & new_unittest("invalid3-extxyz", test_invalid3_extxyz, should_fail=.true.), &
+      & new_unittest("invalid4-extxyz", test_invalid4_extxyz, should_fail=.true.), &
+      & new_unittest("invalid5-extxyz", test_invalid5_extxyz, should_fail=.true.), &
+      & new_unittest("invalid6-extxyz", test_invalid6_extxyz, should_fail=.true.), &
+      & new_unittest("invalid7-extxyz", test_invalid7_extxyz, should_fail=.true.), &
+      & new_unittest("invalid8-extxyz", test_invalid8_extxyz, should_fail=.true.), &
+      & new_unittest("invalid9-extxyz", test_invalid9_extxyz, should_fail=.true.), &
+      & new_unittest("invalid10-extxyz", test_invalid10_extxyz, should_fail=.true.), &
+      & new_unittest("invalid11-extxyz", test_invalid11_extxyz, should_fail=.true.), &
+      & new_unittest("invalid12-extxyz", test_invalid12_extxyz, should_fail=.true.), &
       & new_unittest("invalid1-xyz", test_invalid1_xyz, should_fail=.true.), &
       & new_unittest("invalid2-xyz", test_invalid2_xyz, should_fail=.true.), &
       & new_unittest("invalid3-xyz", test_invalid3_xyz, should_fail=.true.), &
@@ -445,6 +461,243 @@ subroutine test_invalid7_xyz(error)
    close(unit)
 
 end subroutine test_invalid7_xyz
+
+
+subroutine test_valid6_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+   real(wp), parameter :: lattice_ref(3, 3) = reshape([ &
+      & 5.0_wp, 0.0_wp, 0.0_wp, &
+      & 0.0_wp, 6.0_wp, 0.0_wp, &
+      & 0.0_wp, 0.0_wp, 7.0_wp], [3, 3]) * aatoau
+
+   open(status="scratch", newunit=unit)
+   write(unit, "(a)") &
+      "2", &
+      'Lattice="5.0 0.0 0.0 0.0 6.0 0.0 0.0 0.0 7.0" '// &
+      & 'Properties=forces:R:3:species:S:1:pos:R:3 energy=-1.2 pbc="T F T" '// &
+      & 'comment="periodic test"', &
+      "0.1 0.2 0.3 H 1.0 2.0 3.0", &
+      "0.4 0.5 0.6 O 4.0 5.0 6.0"
+   rewind(unit)
+
+   call read_xyz(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 2, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, count(struc%periodic), 2, "Periodicity does not match")
+   if (allocated(error)) return
+   call check(error, maxval(abs(struc%lattice-lattice_ref)), 0.0_wp, &
+      & "Lattice does not match", thr=1.0e-12_wp)
+   if (allocated(error)) return
+   call check(error, maxval(abs(struc%xyz(:, 1)-[1.0_wp, 2.0_wp, 3.0_wp]*aatoau)), &
+      & 0.0_wp, "Coordinates do not match", thr=1.0e-12_wp)
+   if (allocated(error)) return
+   call check(error, struc%comment, "periodic test")
+
+end subroutine test_valid6_extxyz
+
+
+subroutine test_valid7_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status="scratch", newunit=unit)
+   write(unit, "(a)") &
+      "2", &
+      "Properties=pos:R:3:Z:I:1 pbc=[F,F,F]", &
+      "1.0 2.0 3.0 1", &
+      "4.0 5.0 6.0 8"
+   rewind(unit)
+
+   call read_xyz(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, struc%nat, 2, "Number of atoms does not match")
+   if (allocated(error)) return
+   call check(error, struc%nid, 2, "Number of species does not match")
+   if (allocated(error)) return
+   call check(error, count(struc%periodic), 0, "Periodicity does not match")
+   if (allocated(error)) return
+   call check(error, struc%sym(struc%id(1)), "H")
+   if (allocated(error)) return
+   call check(error, struc%sym(struc%id(2)), "O")
+
+end subroutine test_valid7_extxyz
+
+
+subroutine test_invalid1_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   call check_invalid_extxyz(error, &
+      & 'Properties=species:S:1:pos:R:3 Lattice="1.0 0.0"', &
+      & "H 0.0 0.0 0.0")
+
+end subroutine test_invalid1_extxyz
+
+
+subroutine test_invalid2_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   call check_invalid_extxyz(error, &
+      & 'Properties=species:S:1:pos:R:3 pbc="T F"', &
+      & "H 0.0 0.0 0.0")
+
+end subroutine test_invalid2_extxyz
+
+
+subroutine test_invalid3_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   call check_invalid_extxyz(error, &
+      & 'Properties=species:S:1:pos:R:3 comment="unterminated', &
+      & "H 0.0 0.0 0.0")
+
+end subroutine test_invalid3_extxyz
+
+
+subroutine test_invalid4_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   call check_invalid_extxyz(error, &
+      & "Properties=species:S:1:pos:R", &
+      & "H 0.0 0.0 0.0")
+
+end subroutine test_invalid4_extxyz
+
+
+subroutine test_invalid5_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   call check_invalid_extxyz(error, &
+      & "Properties=species:R:1:pos:R:3", &
+      & "H 0.0 0.0 0.0")
+
+end subroutine test_invalid5_extxyz
+
+
+subroutine test_invalid6_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   call check_invalid_extxyz(error, &
+      & "Properties=species:S:1:pos:R:2", &
+      & "H 0.0 0.0")
+
+end subroutine test_invalid6_extxyz
+
+
+subroutine test_invalid7_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   call check_invalid_extxyz(error, &
+      & "Properties=pos:R:3", &
+      & "0.0 0.0 0.0")
+
+end subroutine test_invalid7_extxyz
+
+
+subroutine test_invalid8_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   call check_invalid_extxyz(error, &
+      & "Properties=species:S:1", &
+      & "H")
+
+end subroutine test_invalid8_extxyz
+
+
+subroutine test_invalid9_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   call check_invalid_extxyz(error, &
+      & "Properties=species:S:1:pos:R:3", &
+      & "H 0.0 0.0")
+
+end subroutine test_invalid9_extxyz
+
+
+subroutine test_invalid10_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   call check_invalid_extxyz(error, &
+      & "Properties=species:S:1:pos:R:3", &
+      & "H 0.0 0.0 0.0 extra")
+
+end subroutine test_invalid10_extxyz
+
+
+subroutine test_invalid11_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   call check_invalid_extxyz(error, &
+      & "Properties=species:S:1:pos:R:3", &
+      & "H invalid 0.0 0.0")
+
+end subroutine test_invalid11_extxyz
+
+
+subroutine test_invalid12_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   call check_invalid_extxyz(error, &
+      & "Properties=Z:I:1:pos:R:3", &
+      & "0 0.0 0.0 0.0")
+
+end subroutine test_invalid12_extxyz
+
+
+subroutine check_invalid_extxyz(error, header, atom)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   character(len=*), intent(in) :: header, atom
+   type(structure_type) :: struc
+   integer :: unit
+
+   open(status="scratch", newunit=unit)
+   write(unit, "(a)") "1", header, atom
+   rewind(unit)
+
+   call read_xyz(struc, unit, error)
+   close(unit)
+
+end subroutine check_invalid_extxyz
 
 
 end module test_read_xyz

--- a/test/test_write.f90
+++ b/test/test_write.f90
@@ -45,7 +45,8 @@ subroutine collect_write(testsuite)
       & new_unittest("valid-qcschema", test_qcschema, should_fail=.not.get_mctc_feature("json")), &
       & new_unittest("valid-vasp", test_vasp), &
       & new_unittest("valid-coord", test_coord), &
-      & new_unittest("valid-xyz", test_xyz) &
+      & new_unittest("valid-xyz", test_xyz), &
+      & new_unittest("valid-extxyz", test_extxyz) &
       & ]
 
 end subroutine collect_write
@@ -226,9 +227,43 @@ subroutine test_xyz(error)
 
    type(structure_type) :: struc
    character(len=:), allocatable :: name
+   real(wp), allocatable :: lattice(:, :)
    integer :: unit
 
    name = get_name() // ".xyz"
+
+   call get_structure(struc, "x01")
+   lattice = struc%lattice
+
+   call write_structure(struc, name, error)
+   if (.not.allocated(error)) then
+      call read_structure(struc, name, error)
+   end if
+
+   if (.not.allocated(error)) then
+      call check(error, maxval(abs(struc%lattice-lattice)), 0.0_wp, &
+         & "Lattice does not match", thr=1.0e-12_wp)
+   end if
+   if (.not.allocated(error)) then
+      call check(error, all(struc%periodic), "Periodicity does not match")
+   end if
+
+   open(file=name, newunit=unit)
+   close(unit, status="delete")
+
+end subroutine test_xyz
+
+
+subroutine test_extxyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   character(len=:), allocatable :: name
+   integer :: unit
+
+   name = get_name() // ".extxyz"
 
    call get_structure(struc, "mindless04")
 
@@ -240,7 +275,7 @@ subroutine test_xyz(error)
    open(file=name, newunit=unit)
    close(unit, status="delete")
 
-end subroutine test_xyz
+end subroutine test_extxyz
 
 
 subroutine test_qcschema(error)

--- a/test/test_write_xyz.f90
+++ b/test/test_write_xyz.f90
@@ -13,9 +13,10 @@
 ! limitations under the License.
 
 module test_write_xyz
+   use mctc_env_accuracy, only : wp
    use mctc_env_testing, only : new_unittest, unittest_type, error_type, check
    use mctc_io_read_xyz, only : read_xyz
-   use mctc_io_structure, only : structure_type
+   use mctc_io_structure, only : structure_type, new
    use mctc_io_write_xyz, only : write_xyz
    use testsuite_structure, only : get_structure
    implicit none
@@ -34,7 +35,8 @@ subroutine collect_write_xyz(testsuite)
    type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
    testsuite = [ &
-      & new_unittest("valid1-xyz", test_valid1_xyz) &
+      & new_unittest("valid1-xyz", test_valid1_xyz), &
+      & new_unittest("valid2-periodic-xyz", test_valid2_periodic_xyz) &
       & ]
 
 end subroutine collect_write_xyz
@@ -66,6 +68,46 @@ subroutine test_valid1_xyz(error)
    if (allocated(error)) return
 
 end subroutine test_valid1_xyz
+
+
+subroutine test_valid2_periodic_xyz(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: struc
+   integer :: unit
+   character(len=1), parameter :: sym(2) = ["H", "O"]
+   real(wp), parameter :: xyz(3, 2) = reshape([ &
+      & 1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, 6.0_wp], [3, 2])
+   real(wp), parameter :: lattice(3, 3) = reshape([ &
+      & 10.0_wp, 0.0_wp, 0.0_wp, &
+      & 1.0_wp, 11.0_wp, 0.0_wp, &
+      & 2.0_wp, 3.0_wp, 12.0_wp], [3, 3])
+   logical, parameter :: periodic(3) = [.true., .false., .true.]
+
+   call new(struc, sym, xyz, lattice=lattice, periodic=periodic)
+   struc%comment = 'roundtrip "test"'
+
+   open(status="scratch", newunit=unit)
+   call write_xyz(struc, unit)
+   rewind(unit)
+
+   call read_xyz(struc, unit, error)
+   close(unit)
+   if (allocated(error)) return
+
+   call check(error, count(struc%periodic), 2, "Periodicity does not match")
+   if (allocated(error)) return
+   call check(error, maxval(abs(struc%lattice-lattice)), 0.0_wp, &
+      & "Lattice does not match", thr=1.0e-12_wp)
+   if (allocated(error)) return
+   call check(error, maxval(abs(struc%xyz-xyz)), 0.0_wp, &
+      & "Coordinates do not match", thr=1.0e-12_wp)
+   if (allocated(error)) return
+   call check(error, struc%comment, 'roundtrip "test"')
+
+end subroutine test_valid2_periodic_xyz
 
 
 end module test_write_xyz


### PR DESCRIPTION
Resolves #116.

The existing `.xyz` extension is treated as the generic XYZ format. When writing, structures containing lattice or periodicity information are automatically written as Extended XYZ so that this information is preserved, while non-periodic structures continue to use the traditional XYZ representation. Extended XYZ output can also be requested explicitly with `-o extxyz`.

When reading `.xyz` files, Extended XYZ metadata is detected automatically and structural information such as `Lattice`, `pbc`, `species`/`Z`, and `pos` is restored. Unknown per-atom properties are parsed according to the `Properties` schema and skipped safely when they are not represented by `structure_type`.